### PR TITLE
Handle portrait encoded as byte array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # UNRELEASED Release 4.1.0:
 * improved display of credentials
-* 
+* Handle portraits encoded as actual byte arrays
 
 # Release 4.0.0:
 * Update to VcLib 4.1.1

--- a/shared/src/commonMain/kotlin/data/CredentialExtractor.kt
+++ b/shared/src/commonMain/kotlin/data/CredentialExtractor.kt
@@ -347,15 +347,25 @@ class CredentialExtractor(
                     when (credential.scheme) {
                         is IdAustriaScheme -> credential.disclosures.filter {
                             it.value?.claimName == IdAustriaScheme.Attributes.PORTRAIT
-                        }.firstNotNullOfOrNull { it.value?.claimValue as String }
-                            ?.decodeBase64Bytes()
+                        }.firstNotNullOfOrNull {
+                            when (val value = it.value?.claimValue) {
+                                is ByteArray -> value
+                                is String -> value.decodeBase64Bytes()
+                                else -> null
+                            }
+                        }
 
                         is EuPidScheme -> null
 
                         is MobileDrivingLicenceScheme -> credential.disclosures.filter {
                             it.value?.claimName == MobileDrivingLicenceDataElements.PORTRAIT
-                        }.firstNotNullOfOrNull { it.value?.claimValue as String }
-                            ?.decodeBase64Bytes()
+                        }.firstNotNullOfOrNull {
+                            when (val value = it.value?.claimValue) {
+                                is ByteArray -> value
+                                is String -> value.decodeBase64Bytes()
+                                else -> null
+                            }
+                        }
 
                         else -> null
                     }
@@ -367,7 +377,13 @@ class CredentialExtractor(
                             IdAustriaScheme.isoNamespace
                         )?.entries?.firstOrNull {
                             it.value.elementIdentifier == IdAustriaScheme.Attributes.PORTRAIT
-                        }?.value?.elementValue?.let { (it as String).decodeBase64Bytes() }
+                        }?.value?.elementValue?.let {
+                            when (it) {
+                                is ByteArray -> it
+                                is String -> it.decodeBase64Bytes()
+                                else -> null
+                            }
+                        }
 
                         is EuPidScheme -> null
 
@@ -375,7 +391,13 @@ class CredentialExtractor(
                             MobileDrivingLicenceScheme.isoNamespace
                         )?.entries?.firstOrNull {
                             it.value.elementIdentifier == MobileDrivingLicenceDataElements.PORTRAIT
-                        }?.value?.elementValue?.let { (it as String).decodeBase64Bytes() }
+                        }?.value?.elementValue?.let {
+                            when (it) {
+                                is ByteArray -> it
+                                is String -> it.decodeBase64Bytes()
+                                else -> null
+                            }
+                        }
 
                         else -> null
                     }
@@ -468,7 +490,7 @@ class CredentialExtractor(
                             EuPidScheme.isoNamespace
                         )?.entries?.firstOrNull {
                             it.value.elementIdentifier == EuPidScheme.Attributes.NATIONALITY
-                        }?.value?.elementValue?.let { (it as String)}
+                        }?.value?.elementValue?.let { (it as String) }
 
                         is MobileDrivingLicenceScheme -> credential.issuerSigned.namespaces?.get(
                             MobileDrivingLicenceScheme.isoNamespace
@@ -1700,7 +1722,8 @@ class CredentialExtractor(
                             )?.entries?.firstOrNull {
                                 it.value.elementIdentifier == MobileDrivingLicenceDataElements.ISSUE_DATE
                             }?.value?.elementValue
-                            elementValue?.let { it as LocalDate } ?: elementValue?.let { (it as String) }?.let { LocalDate.parse(it) }
+                            elementValue?.let { it as LocalDate } ?: elementValue?.let { (it as String) }
+                                ?.let { LocalDate.parse(it) }
                         }
 
                         else -> null
@@ -1735,7 +1758,8 @@ class CredentialExtractor(
                             )?.entries?.firstOrNull {
                                 it.value.elementIdentifier == MobileDrivingLicenceDataElements.EXPIRY_DATE
                             }?.value?.elementValue
-                            elementValue?.let { it as LocalDate } ?: elementValue?.let { (it as String) }?.let { LocalDate.parse(it) }
+                            elementValue?.let { it as LocalDate } ?: elementValue?.let { (it as String) }
+                                ?.let { LocalDate.parse(it) }
                         }
 
                         else -> null

--- a/shared/src/commonMain/kotlin/data/credentials/IdAustriaCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/IdAustriaCredentialAdapter.kt
@@ -220,7 +220,11 @@ private class IdAustriaCredentialIsoMdocAdapter(
 
     override val portraitRaw: ByteArray? by lazy {
         idAustriaNamespace[IdAustriaScheme.Attributes.PORTRAIT]?.let {
-            (it as String).decodeBase64Bytes()
+            when (it) {
+                is ByteArray -> it
+                is String -> it.decodeBase64Bytes()
+                else -> null
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/data/credentials/MobileDrivingLicenceCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/MobileDrivingLicenceCredentialAdapter.kt
@@ -260,7 +260,11 @@ private class MobileDrivingLicenceCredentialIsoMdocAdapter(
 
     override val portraitRaw: ByteArray?
         get() = mobileDrivingLicenceNamespace[MobileDrivingLicenceDataElements.PORTRAIT]?.let {
-            (it as String).decodeBase64Bytes()
+            when (it) {
+                is ByteArray -> it
+                is String -> it.decodeBase64Bytes()
+                else -> null
+            }
         }
 
     override val documentNumber: String?


### PR DESCRIPTION
Previously, the issuing service did encode byte arrays as Base64 strings, but that was wrong as will be fixed in a future deployment