### PR TITLE
Fix/dependency cleanup

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -1,5 +1,6 @@
 name: Test Android implementation
-on: [push]
+on: workflow_dispatch
+# TODO: fix android emulator tests and enable this on every push!
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -1,5 +1,5 @@
 name: Test Android implementation
-on: workflow_dispatch
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -1,5 +1,5 @@
 name: Test iOS implementation
-on: workflow_dispatch
+on: [push]
 jobs:
   build:
     runs-on: macos-15

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -49,9 +49,6 @@ kotlin {
                 implementation(ktor("client-content-negotiation"))
                 implementation(ktor("serialization-kotlinx-json"))
 
-                // Add arrow-core dependency because of https://youtrack.jetbrains.com/issue/KT-73858/NullPointerException-when-building-CMP-ios-App
-                implementation("io.arrow-kt:arrow-core:1.2.4")
-
                 implementation(libs.identity)
             }
         }


### PR DESCRIPTION
turns out, there never was an issue with the latest VC-K version and the KLIB resolver!

This PR removes the dependency we forgot to remove and enables iOS tests on push