### PR TITLE
Adjust logging in release builds

### DIFF
--- a/androidApp/src/androidMain/kotlin/at/asitplus/wallet/app/android/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/at/asitplus/wallet/app/android/MainActivity.kt
@@ -6,10 +6,11 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import appLink
+import at.asitplus.wallet.app.android.dcapi.WalletAPIData
 import at.asitplus.wallet.app.common.BuildContext
+import at.asitplus.wallet.app.common.BuildType
 import com.google.android.gms.identitycredentials.GetCredentialResponse
 import com.google.android.gms.identitycredentials.IntentHelper
-import at.asitplus.wallet.app.android.dcapi.WalletAPIData
 
 
 class MainActivity : AppCompatActivity() {
@@ -23,7 +24,7 @@ class MainActivity : AppCompatActivity() {
         setContent {
             MainView(
                 buildContext = BuildContext(
-                    buildType = BuildConfig.BUILD_TYPE,
+                    buildType = BuildType.valueOf(BuildConfig.BUILD_TYPE.uppercase()),
                     packageName = BuildConfig.APPLICATION_ID,
                     versionCode = BuildConfig.VERSION_CODE,
                     versionName = BuildConfig.VERSION_NAME,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -8,7 +8,7 @@ struct ComposeView: UIViewControllerRepresentable {
         #if DEBUG
         let buildType = BuildType.debug
         #else
-        let buildType = BuildType.release
+        let buildType = BuildType.release_
         #endif
         return Main_iosKt.MainViewController(
             platformAdapter: SwiftPlatformAdapter(),

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -6,9 +6,9 @@ struct ComposeView: UIViewControllerRepresentable {
     
     func makeUIViewController(context: Context) -> UIViewController {
         #if DEBUG
-        let buildType = "debug"
+        let buildType = BuildType.debug
         #else
-        let buildType = "release"
+        let buildType = BuildType.release
         #endif
         return Main_iosKt.MainViewController(
             platformAdapter: SwiftPlatformAdapter(),

--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -17,11 +17,6 @@ import ui.theme.WalletTheme
  */
 var appLink = mutableStateOf<String?>(null)
 
-/**
- * Global variable to test at least something from the iOS UITest
- */
-var iosTestValue = Configuration.IOS_TEST_VALUE
-
 internal object AppTestTags {
     const val rootScaffold = "rootScaffold"
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/BuildContext.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/BuildContext.kt
@@ -7,8 +7,13 @@ enum class BuildEnvironment(val abbreviation: String) {
 }
 
 data class BuildContext(
-    val buildType: String,
+    val buildType: BuildType,
     val packageName: String,
     val versionCode: Int,
     val versionName: String,
 )
+
+enum class BuildType(val stringRepresentaiton: String) {
+    DEBUG("debug"),
+    RELEASE("release")
+}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/BuildContext.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/BuildContext.kt
@@ -1,11 +1,5 @@
 package at.asitplus.wallet.app.common
 
-enum class BuildEnvironment(val abbreviation: String) {
-    Development("D"),
-    QualityAssurance("Q"),
-    Production("P");
-}
-
 data class BuildContext(
     val buildType: BuildType,
     val packageName: String,

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Configuration.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Configuration.kt
@@ -1,7 +1,6 @@
 package at.asitplus.wallet.app.common
 
 object Configuration {
-    val BUILD_FOR_STAGE = BuildEnvironment.Development.abbreviation
     val USER_AUTHENTICATION_TIMEOUT_SECONDS = 15
 
     const val DATASTORE_KEY_CONFIG = "config"
@@ -10,8 +9,6 @@ object Configuration {
     const val DATASTORE_KEY_COOKIES = "cookies"
     const val DEBUG_DATASTORE_KEY = "DBGKEY"
     const val DEBUG_DATASTORE_VALUE = "DBGVALUE"
-
-    const val IOS_TEST_VALUE = "TESTVALUE"
 
     const val KS_ALIAS = "wallet-supreme-binding-key"
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
@@ -64,7 +64,7 @@ class WalletMain(
         at.asitplus.wallet.companyregistration.Initializer.initWithVCK()
         at.asitplus.wallet.eprescription.Initializer.initWithVCK()
         Napier.takeLogarithm()
-        Napier.base(AntilogAdapter(platformAdapter, ""))
+        Napier.base(AntilogAdapter(platformAdapter, "", buildContext.buildType))
     }
 
     @Throws(Throwable::class)

--- a/shared/src/commonMain/kotlin/data/storage/AntilogAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/storage/AntilogAdapter.kt
@@ -29,9 +29,7 @@ class AntilogAdapter(val platformAdapter: PlatformAdapter, private val defaultTa
         val time = "${hour}:${minute}"
         val logTag = tag ?: defaultTag
         val pad = 15
-
-
-
+        
         val message = message ?: ""
 
         val data: String

--- a/shared/src/commonMain/kotlin/data/storage/AntilogAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/storage/AntilogAdapter.kt
@@ -1,5 +1,6 @@
 package data.storage
 
+import at.asitplus.wallet.app.common.BuildType
 import at.asitplus.wallet.app.common.PlatformAdapter
 import io.github.aakira.napier.Antilog
 import io.github.aakira.napier.DebugAntilog
@@ -9,13 +10,18 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
-class AntilogAdapter(val platformAdapter: PlatformAdapter, private val defaultTag: String): Antilog() {
+class AntilogAdapter(val platformAdapter: PlatformAdapter, private val defaultTag: String, private val buildType: BuildType): Antilog() {
     private val debugAntilogAdapter = DebugAntilog(defaultTag = defaultTag)
 
     /**
      * Modified from DebugAntiLog
      */
     override fun performLog(priority: LogLevel, tag: String?, throwable: Throwable?, message: String?) {
+
+        if ( buildType == BuildType.RELEASE && (priority == LogLevel.VERBOSE || priority == LogLevel.DEBUG) ) {
+            return
+        }
+
         val now: Instant = Clock.System.now()
         val date = now.toLocalDateTime(TimeZone.currentSystemDefault())
         val hour = date.hour.toString().padStart(2, '0')
@@ -24,7 +30,11 @@ class AntilogAdapter(val platformAdapter: PlatformAdapter, private val defaultTa
         val logTag = tag ?: defaultTag
         val pad = 15
 
+
+
         val message = message ?: ""
+
+        var data : String = ""
 
         when (priority) {
             LogLevel.ERROR -> {
@@ -32,15 +42,15 @@ class AntilogAdapter(val platformAdapter: PlatformAdapter, private val defaultTa
                 val cause = throwable?.cause?.message ?: "Unknown Cause"
                 val stackTrace = throwable?.stackTraceToString() ?: ""
                 val info = "[${time}] ERROR".padEnd(pad, ' ')
-                val data = ("$info $logTag : $message, $cause\n$stackTrace\n")
-                platformAdapter.writeToFile(data, "log.txt", "logs")
+                data = ("$info $logTag : $message, $cause\n$stackTrace\n")
             }
             else -> {
                 val info = "[${time}] ${priority}".padEnd(pad, ' ')
-                val data = ("$info $logTag : $message\n")
-                platformAdapter.writeToFile(data, "log.txt", "logs")
+                data = ("$info $logTag : $message\n")
             }
         }
+
+        platformAdapter.writeToFile(data, "log.txt", "logs")
         debugAntilogAdapter.log(priority, tag, throwable, message)
     }
 }

--- a/shared/src/commonMain/kotlin/data/storage/AntilogAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/storage/AntilogAdapter.kt
@@ -34,7 +34,7 @@ class AntilogAdapter(val platformAdapter: PlatformAdapter, private val defaultTa
 
         val message = message ?: ""
 
-        var data : String = ""
+        val data: String
 
         when (priority) {
             LogLevel.ERROR -> {

--- a/shared/src/commonMain/kotlin/ui/viewmodels/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/SettingsViewModel.kt
@@ -1,9 +1,8 @@
 package ui.viewmodels
 
-import at.asitplus.wallet.app.common.Configuration
-import at.asitplus.wallet.app.common.WalletMain
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.error_feature_not_yet_available
+import at.asitplus.wallet.app.common.WalletMain
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 
@@ -11,7 +10,6 @@ class SettingsViewModel (walletMain: WalletMain,
                          val onClickShareLogFile: () -> Unit,
                          val onClickClearLogFile: () -> Unit,
                          val onClickResetApp: () -> Unit) {
-    val stage = Configuration.BUILD_FOR_STAGE
     val buildType = walletMain.buildContext.buildType
     val version = walletMain.buildContext.versionName
 

--- a/shared/src/commonMain/kotlin/ui/views/SettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/SettingsView.kt
@@ -190,7 +190,7 @@ fun SettingsView(
                         modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)
                             .fillMaxWidth()
                     ) {
-                        Text("${stringResource(Res.string.text_label_stage)}: ${vm.stage})")
+                        Text("${stringResource(Res.string.text_label_stage)}: ${vm.stage}")
                         Text("${stringResource(Res.string.text_label_build)}: ${vm.version}-${vm.buildType}")
                     }
                 }

--- a/shared/src/commonMain/kotlin/ui/views/SettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/SettingsView.kt
@@ -46,7 +46,6 @@ import at.asitplus.valera.resources.reset_app_alert_text
 import at.asitplus.valera.resources.section_heading_actions
 import at.asitplus.valera.resources.section_heading_information
 import at.asitplus.valera.resources.text_label_build
-import at.asitplus.valera.resources.text_label_stage
 import at.asitplus.valera.resources.warning
 import org.jetbrains.compose.resources.stringResource
 import ui.composables.Logo
@@ -186,11 +185,10 @@ fun SettingsView(
                 }
                 Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.Bottom) {
                     Row(
-                        horizontalArrangement = Arrangement.SpaceBetween,
+                        horizontalArrangement = Arrangement.Center,
                         modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)
                             .fillMaxWidth()
                     ) {
-                        Text("${stringResource(Res.string.text_label_stage)}: ${vm.stage}")
                         Text("${stringResource(Res.string.text_label_build)}: ${vm.version}-${vm.buildType}")
                     }
                 }

--- a/shared/src/commonTest/kotlin/InstrumentedTestsSuite.kt
+++ b/shared/src/commonTest/kotlin/InstrumentedTestsSuite.kt
@@ -1,3 +1,4 @@
+
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -26,6 +27,7 @@ import at.asitplus.valera.resources.button_label_start
 import at.asitplus.valera.resources.content_description_portrait
 import at.asitplus.valera.resources.section_heading_age_data
 import at.asitplus.wallet.app.common.BuildContext
+import at.asitplus.wallet.app.common.BuildType
 import at.asitplus.wallet.app.common.KeystoreService
 import at.asitplus.wallet.app.common.PlatformAdapter
 import at.asitplus.wallet.app.common.WalletCryptoService
@@ -62,7 +64,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.compose.resources.getString
 import ui.navigation.NavigatorTestTags
 import ui.navigation.Routes.OnboardingWrapperTestTags
-import ui.navigation.handleIntent
 import ui.views.OnboardingStartScreenTestTag
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
@@ -314,7 +315,7 @@ private fun createWalletMain(platformAdapter: PlatformAdapter): WalletMain {
         platformAdapter = platformAdapter,
         scope = CoroutineScope(Dispatchers.Default),
         buildContext = BuildContext(
-            buildType = "debug",
+            buildType = BuildType.DEBUG,
             packageName = "test",
             versionCode = 0,
             versionName = "0.0.0",


### PR DESCRIPTION
- Don't log verbose and debug in release builds
- Remove unused `IOS_TEST_VALUE `
- Add BuildType enum instead of string
- Remove stage from configuration