### PR TITLE
Use correct name in BuildContext

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -17,7 +17,7 @@ struct ComposeView: UIViewControllerRepresentable {
                 packageName: Bundle.main.bundleIdentifier ?? "at.asitplus.wallet.compose",
                 versionCode: Bundle.main.infoDictionary?["CFBundleVersion"] as? Int32 ?? 1,
                 versionName: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String  ?? "1.0.0",
-                operatingSystemString: "iOS " + UIDevice.current.systemVersion
+                osVersion: "iOS " + UIDevice.current.systemVersion
             )
         )
     }


### PR DESCRIPTION
Fix name of BuildContext parameter