### PR TITLE
feat(signing): add HTTP header with QTSP identifier ...

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/DocumentProcessing.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/DocumentProcessing.kt
@@ -8,6 +8,7 @@ import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.rqes.RqesOpenId4VpHolder
 import io.ktor.client.HttpClient
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -189,6 +190,7 @@ internal suspend fun getFinishedDocuments(
     qtspHost: String,
     signatureResponse: SignatureResponse,
     transactionTokens: List<String>,
+    qtspIdentifier: String,
 ): List<FinishedDocument> {
     val finishedDocuments = mutableListOf<FinishedDocument>()
 
@@ -201,6 +203,7 @@ internal suspend fun getFinishedDocuments(
             for (wrappedSig in signatures) {
                 val finishedDocResponse = client.post("${qtspHost}/sca/finalize") {
                     contentType(ContentType.Application.Json)
+                    header("Wallet-QTSP-ID", qtspIdentifier) 
                     setBody(
                         vckJsonSerializer.encodeToString(
                             wrappedSig

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/SigningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/SigningService.kt
@@ -177,7 +177,8 @@ class SigningService(
         }.body<SignatureResponse>()
 
         val transactionTokens = this.transactionTokens
-        val signedDocuments = getFinishedDocuments(client, pdfSigningService, signatures, transactionTokens)
+        val signedDocuments = getFinishedDocuments(client, pdfSigningService, signatures, transactionTokens, config.getCurrent().identifier)
+
 
 
         val signedDocList = vckJsonSerializer.encodeToJsonElement(


### PR DESCRIPTION
… to finalize PDF processing request

Reason: can be used for KPI collection in Wallet-centric model for Potential UC5