### PR TITLE
QSig: optionally load certificate by credentialInfo 

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/SigningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/SigningService.kt
@@ -423,6 +423,13 @@ val defaultSigningConfig = SigningConfig(
             "https://id.primesign-test.com/realms/qs-staging",
             "https://wallet.a-sit.at/app",
             allowPreload = false
+        ),
+        QtspConfig(
+            "NAMIRIAL",
+            "https://csc-api.fba.users.bit4id.click/api/csc/v2",
+            "https://csc-api.fba.users.bit4id.click/api/csc/v2",
+            "POTENTIAL-UC5",
+            allowPreload = false
         )
     ),
     current = "EGIZ"

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/SigningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/SigningService.kt
@@ -7,10 +7,14 @@ import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.rqes.CredentialInfo
 import at.asitplus.rqes.CredentialInfoRequest
+import at.asitplus.rqes.CredentialListRequest
+import at.asitplus.rqes.CredentialListResponse
 import at.asitplus.rqes.CscCredentialListRequest
 import at.asitplus.rqes.CscCredentialListResponse
 import at.asitplus.rqes.SignatureRequestParameters
 import at.asitplus.rqes.SignatureResponse
+import at.asitplus.rqes.collection_entries.CertificateParameters
+import at.asitplus.rqes.collection_entries.CertificateParameters.CertStatus
 import at.asitplus.rqes.enums.CertificateOptions
 import at.asitplus.signum.indispensable.X509SignatureAlgorithm
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
@@ -288,7 +292,7 @@ class SigningService(
     }
 
     private suspend fun getCredentialInfo(token: TokenResponseParameters): CredentialInfo {
-        val credentialListRequest = CscCredentialListRequest(
+        val credentialListRequest = CredentialListRequest(
             credentialInfo = true,
             certificates = CertificateOptions.SINGLE,
             certInfo = true,
@@ -305,7 +309,7 @@ class SigningService(
             )
             setBody(vckJsonSerializer.encodeToString(credentialListRequest))
         }
-        val credentialListResponse = credentialResponse.body<CscCredentialListResponse>()
+        val credentialListResponse = credentialResponse.body<CredentialListResponse>()
 
         if (credentialListResponse.credentialInfos.isNullOrEmpty()) {
             return getSingleCredentialInfo(token, credentialListResponse.credentialIDs.first());
@@ -333,7 +337,10 @@ class SigningService(
             )
             setBody(vckJsonSerializer.encodeToString(credentialInfoRequest))
         }
-        return credentialResponse.body<CredentialInfo>()
+        val credInfo = credentialResponse.body<CredentialInfo>();
+        return CredentialInfo(credentialId, credInfo.description, credInfo.signatureQualifier, credInfo.keyParameters,
+            credInfo.certParameters, credInfo.authParameters, credInfo.scal, credInfo.multisign)
+
     }
 
     private suspend fun createCredentialAuthRequest(): String {


### PR DESCRIPTION
Use `credentialInfo` end-point to get certificate if `credentialList` does not contain certificate information.

That approach will be needed for _Namirial_ QTSP