### PR TITLE
Use existing preparation state for authentication

### DIFF
--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -30,6 +30,8 @@ import at.asitplus.valera.resources.snackbar_reset_app_successfully
 import at.asitplus.wallet.app.common.WalletMain
 import at.asitplus.wallet.app.common.dcapi.DCAPIRequest
 import at.asitplus.wallet.app.common.decodeImage
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.openid.AuthorizationResponsePreparationState
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -318,16 +320,17 @@ private fun WalletNavHost(
 
             val vm = remember {
                 try {
-                    val request = rdcJsonSerializer
-                        .decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(
-                            route.authenticationRequestParametersFromSerialized
-                        )
+                    val request: RequestParametersFrom<AuthenticationRequestParameters> =
+                        vckJsonSerializer.decodeFromString(route.authenticationRequestParametersFromSerialized)
+                    val preparationState: AuthorizationResponsePreparationState =
+                        vckJsonSerializer.decodeFromString(route.authorizationPreparationStateSerialized)
 
                     DefaultAuthenticationViewModel(
                         spName = null,
                         spLocation = route.recipientLocation,
                         spImage = null,
                         authenticationRequest = request,
+                        preparationState = preparationState,
                         isCrossDeviceFlow = route.isCrossDeviceFlow,
                         navigateUp = navigateBack,
                         navigateToAuthenticationSuccessPage = {

--- a/shared/src/commonMain/kotlin/ui/viewmodels/authentication/DefaultAuthenticationViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/authentication/DefaultAuthenticationViewModel.kt
@@ -3,16 +3,13 @@ package ui.viewmodels.authentication
 import androidx.compose.ui.graphics.ImageBitmap
 import at.asitplus.KmmResult
 import at.asitplus.catching
-import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.rqes.QesInputDescriptor
-import at.asitplus.rqes.collection_entries.TransactionData
 import at.asitplus.wallet.app.common.WalletMain
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
-import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.openid.AuthorizationResponsePreparationState
 
 
@@ -21,6 +18,7 @@ class DefaultAuthenticationViewModel(
     spLocation: String,
     spImage: ImageBitmap?,
     val authenticationRequest: RequestParametersFrom<AuthenticationRequestParameters>,
+    val preparationState: AuthorizationResponsePreparationState,
     val isCrossDeviceFlow: Boolean,
     navigateUp: () -> Unit,
     navigateToAuthenticationSuccessPage: () -> Unit,
@@ -38,26 +36,16 @@ class DefaultAuthenticationViewModel(
     onClickLogo
 ) {
     override val presentationRequest: CredentialPresentationRequest
-        get() = authenticationRequest.parameters.presentationDefinition?.let {
-            CredentialPresentationRequest.PresentationExchangeRequest(
-                presentationDefinition = it,
-                fallbackFormatHolder = authenticationRequest.parameters.clientMetadata?.vpFormats,
-            )
-        } ?: authenticationRequest.parameters.dcqlQuery?.let {
-            CredentialPresentationRequest.DCQLRequest(it)
-        } ?: throw IllegalArgumentException("No credential presentation request has been found.")
+        get() = preparationState.credentialPresentationRequest
+            ?: throw IllegalArgumentException("No credential presentation request has been found.")
 
     @Suppress("DEPRECATION")
     override val transactionData = authenticationRequest.parameters.transactionData?.firstOrNull()
         ?: authenticationRequest.parameters.presentationDefinition
             ?.inputDescriptors?.filterIsInstance<QesInputDescriptor>()?.firstOrNull()?.transactionData?.firstOrNull()
 
-    private lateinit var preparationState: AuthorizationResponsePreparationState
-
     override suspend fun findMatchingCredentials(): KmmResult<CredentialMatchingResult<SubjectCredentialStore.StoreEntry>> =
         catching {
-            preparationState = walletMain.presentationService.getPreparationState(request = authenticationRequest)
-
             return walletMain.presentationService.getMatchingCredentials(preparationState = preparationState)
         }
 


### PR DESCRIPTION
Otherwise the app thinks there is no presentation definition ... which is the case when testing against <https://potential.irn.justica.gov.pt/EUDI_Portal_PoC/LoginEUDIW> (but also needs the fix from https://github.com/a-sit-plus/vck/pull/272)

Maybe @acrusage-iaik can have a look to, if my fix is really correct.