### PR TITLE
EU PID SD-JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  * Improve some error messages
  * Add proximity presentation and verification of ISO credenitals over Bluetooth
  * Add option to open URL from verifier after successful authentication
+ * Add support for EU PID with SD-JWT names from ARF 1.8.0 onwards
 
 # Release 5.5.2
  * Fix presentation of ISO credentials

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ semver = "2.0.0"
 mdl = "1.1.4"
 ida = "3.9.2"
 eupid = "3.0.0"
+eupid-sdjwt = "1.0.0"
 play-services-identity-credentials = "16.0.0-alpha06"
 powerofrepresentation = "1.2.0"
 certificateofresidence = "2.1.2"
@@ -24,6 +25,7 @@ androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.r
 atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "atomicfu" }
 credential-ida = { module = "at.asitplus.wallet:idacredential", version.ref = "ida" }
 credential-eupid = { module = "at.asitplus.wallet:eupidcredential", version.ref = "eupid" }
+credential-eupid-sdjwt = { module = "at.asitplus.wallet:eupidcredential-sdjwt", version.ref = "eupid-sdjwt" }
 credential-powerofrepresentation = { module = "at.asitplus.wallet:powerofrepresentation", version.ref = "powerofrepresentation" }
 credential-certificateofresidence = { module = "at.asitplus.wallet:certificateofresidence", version.ref = "certificateofresidence" }
 credential-companyregistration = { module = "at.asitplus.wallet:company-registration", version.ref = "companyregistration" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
             api(libs.credential.mdl)
             api(libs.credential.ida)
             api(libs.credential.eupid)
+            api(libs.credential.eupid.sdjwt)
             api(libs.credential.powerofrepresentation)
             api(libs.credential.certificateofresidence)
             api(libs.credential.companyregistration)
@@ -145,6 +146,7 @@ exportXCFramework(
         libs.credential.ida,
         libs.credential.mdl,
         libs.credential.eupid,
+        libs.credential.eupid.sdjwt,
         libs.credential.powerofrepresentation,
         libs.credential.certificateofresidence,
         libs.credential.companyregistration,

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
@@ -18,6 +18,7 @@ import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceDataElements
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.data.AttributeIndex
@@ -157,7 +158,7 @@ fun ConstantIndex.CredentialScheme.toJsonElement(
     representation: CredentialRepresentation,
 ): JsonElement {
     val dataElements = when (this) {
-        ConstantIndex.AtomicAttribute2023, IdAustriaScheme, EuPidScheme, MobileDrivingLicenceScheme, HealthIdScheme -> this.claimNames
+        ConstantIndex.AtomicAttribute2023, IdAustriaScheme, EuPidScheme, EuPidSdJwtScheme, MobileDrivingLicenceScheme, HealthIdScheme -> this.claimNames
         // TODO Use: this.claim names for all schemes
         PowerOfRepresentationScheme -> PowerOfRepresentationDataElements.ALL_ELEMENTS
         CertificateOfResidenceScheme -> CertificateOfResidenceDataElements.ALL_ELEMENTS

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
@@ -75,6 +75,7 @@ class WalletMain(
         at.asitplus.wallet.mdl.Initializer.initWithVCK()
         at.asitplus.wallet.idaustria.Initializer.initWithVCK()
         at.asitplus.wallet.eupid.Initializer.initWithVCK()
+        at.asitplus.wallet.eupidsdjwt.Initializer.initWithVCK()
         at.asitplus.wallet.cor.Initializer.initWithVCK()
         at.asitplus.wallet.por.Initializer.initWithVCK()
         at.asitplus.wallet.companyregistration.Initializer.initWithVCK()

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/thirdParty/at/asitplus/wallet/lib/data/CredentialScheme.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/thirdParty/at/asitplus/wallet/lib/data/CredentialScheme.kt
@@ -22,6 +22,7 @@ import at.asitplus.valera.resources.credential_scheme_label_tax_id
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.data.ConstantIndex
@@ -44,6 +45,7 @@ import org.jetbrains.compose.resources.stringResource
 fun ConstantIndex.CredentialScheme?.uiLabel(): String = when (this) {
     is IdAustriaScheme -> stringResource(Res.string.credential_scheme_label_id_austria)
     is EuPidScheme -> stringResource(Res.string.credential_scheme_label_eu_pid)
+    is EuPidSdJwtScheme -> stringResource(Res.string.credential_scheme_label_eu_pid)
     is MobileDrivingLicenceScheme -> stringResource(Res.string.credential_scheme_label_mdl)
     is PowerOfRepresentationScheme -> stringResource(Res.string.credential_scheme_label_power_of_representation)
     is CertificateOfResidenceScheme -> stringResource(Res.string.credential_scheme_label_certificate_of_residence)
@@ -56,6 +58,7 @@ fun ConstantIndex.CredentialScheme?.uiLabel(): String = when (this) {
 suspend fun ConstantIndex.CredentialScheme?.uiLabelNonCompose(): String = when (this) {
     is IdAustriaScheme -> getString(Res.string.credential_scheme_label_id_austria)
     is EuPidScheme -> getString(Res.string.credential_scheme_label_eu_pid)
+    is EuPidSdJwtScheme -> getString(Res.string.credential_scheme_label_eu_pid)
     is MobileDrivingLicenceScheme -> getString(Res.string.credential_scheme_label_mdl)
     is PowerOfRepresentationScheme -> getString(Res.string.credential_scheme_label_power_of_representation)
     is CertificateOfResidenceScheme -> getString(Res.string.credential_scheme_label_certificate_of_residence)
@@ -69,6 +72,7 @@ suspend fun ConstantIndex.CredentialScheme?.uiLabelNonCompose(): String = when (
 fun ConstantIndex.CredentialScheme?.iconLabel(): String = when (this) {
     is IdAustriaScheme -> stringResource(Res.string.credential_scheme_icon_label_id_austria)
     is EuPidScheme -> stringResource(Res.string.credential_scheme_icon_label_eu_pid)
+    is EuPidSdJwtScheme -> stringResource(Res.string.credential_scheme_icon_label_eu_pid)
     is MobileDrivingLicenceScheme -> stringResource(Res.string.credential_scheme_icon_label_mdl)
     is PowerOfRepresentationScheme -> stringResource(Res.string.credential_scheme_icon_label_power_of_representation)
     is CertificateOfResidenceScheme -> stringResource(Res.string.credential_scheme_icon_label_certificate_of_residence)
@@ -85,6 +89,7 @@ fun ConstantIndex.CredentialScheme.getLocalization(path: NormalizedJsonPath): St
     is CompanyRegistrationScheme -> { CompanyRegistrationCredentialAttributeTranslator.translate(path) }
     is HealthIdScheme -> { HealthIdCredentialAttributeTranslator.translate(path) }
     is EuPidScheme -> { EuPidCredentialAttributeTranslator.translate(path) }
+    is EuPidSdJwtScheme -> { EuPidCredentialAttributeTranslator.translate(path) }
     is IdAustriaScheme -> { IdAustriaCredentialAttributeTranslator.translate(path) }
     is TaxIdScheme -> { TaxIdCredentialAttributeTranslator.translate(path) }
     else -> { IdAustriaCredentialAttributeTranslator.translate(path) }

--- a/shared/src/commonMain/kotlin/data/credentials/CertificateOfResidenceCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/CertificateOfResidenceCredentialAdapter.kt
@@ -2,7 +2,6 @@ package data.credentials
 
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
-import at.asitplus.wallet.cor.CertificateOfResidenceDataElements
 import at.asitplus.wallet.cor.CertificateOfResidenceDataElements.ADMINISTRATIVE_NUMBER
 import at.asitplus.wallet.cor.CertificateOfResidenceDataElements.ARRIVAL_DATE
 import at.asitplus.wallet.cor.CertificateOfResidenceDataElements.Address
@@ -31,6 +30,7 @@ import at.asitplus.wallet.cor.CertificateOfResidenceDataElements.RESIDENCE_ADDRE
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.IsoIec5218Gender
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import data.Attribute
 import kotlinx.datetime.Instant
@@ -53,7 +53,7 @@ sealed class CertificateOfResidenceCredentialAdapter : CredentialAdapter() {
                 FAMILY_NAME -> Attribute.fromValue(familyName)
                 GIVEN_NAME -> Attribute.fromValue(givenName)
                 BIRTH_DATE -> Attribute.fromValue(birthDate)
-                RESIDENCE_ADDRESS -> with(CertificateOfResidenceDataElements.Address) {
+                RESIDENCE_ADDRESS -> with(Address) {
                     when (val second = path.segments.drop(1).firstOrNull()) {
                         is NormalizedJsonPathSegment.NameSegment -> when (second.memberName) {
                             PO_BOX -> Attribute.fromValue(residenceAddressPoBox)
@@ -136,6 +136,9 @@ sealed class CertificateOfResidenceCredentialAdapter : CredentialAdapter() {
 private class CertificateOfResidenceCredentialSdJwtAdapter(
     private val attributes: Map<String, JsonPrimitive>,
 ) : CertificateOfResidenceCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = CertificateOfResidenceScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -219,6 +222,9 @@ private class CertificateOfResidenceCredentialSdJwtAdapter(
 private class CertificateOfResidenceComplexCredentialSdJwtAdapter(
     private val attributes: JsonObject,
 ) : CertificateOfResidenceCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = CertificateOfResidenceScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 

--- a/shared/src/commonMain/kotlin/data/credentials/CompanyRegistrationCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/CompanyRegistrationCredentialAdapter.kt
@@ -20,6 +20,7 @@ import at.asitplus.wallet.companyregistration.CompanyRegistrationDataElements.VA
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.companyregistration.ContactData
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore.StoreEntry
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import data.Attribute
@@ -84,6 +85,9 @@ sealed class CompanyRegistrationCredentialAdapter : CredentialAdapter() {
 private class CompanyRegistrationCredentialSdJwtAdapter(
     private val attributes: Map<String, JsonPrimitive>,
 ) : CompanyRegistrationCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = CompanyRegistrationScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -127,6 +131,9 @@ private class CompanyRegistrationCredentialSdJwtAdapter(
 private class CompanyRegistrationCredentialComplexSdJwtAdapter(
     private val attributes: JsonObject,
 ) : CompanyRegistrationCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = CompanyRegistrationScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 

--- a/shared/src/commonMain/kotlin/data/credentials/CredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/CredentialAdapter.kt
@@ -29,6 +29,8 @@ abstract class CredentialAdapter {
 
     abstract val representation: ConstantIndex.CredentialRepresentation
 
+    abstract val scheme: ConstantIndex.CredentialScheme
+
     companion object {
         fun SubjectCredentialStore.StoreEntry.SdJwt.toAttributeMap() =
             disclosures.values.filterNotNull()

--- a/shared/src/commonMain/kotlin/data/credentials/CredentialAttributeCategorization.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/CredentialAttributeCategorization.kt
@@ -4,6 +4,7 @@ import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.data.ConstantIndex
@@ -27,8 +28,8 @@ interface CredentialAttributeCategorization {
             representation: ConstantIndex.CredentialRepresentation
         ): Template = when (scheme) {
             is IdAustriaScheme -> IdAustriaCredentialAttributeCategorization
-            is EuPidScheme -> // TODO When mapping is confirmed if (representation == ConstantIndex.CredentialRepresentation.SD_JWT) EuPidCredentialSdJwtAttributeCategorization else EuPidCredentialAttributeCategorization
-                EuPidCredentialAttributeCategorization
+            is EuPidScheme -> EuPidCredentialAttributeCategorization
+            is EuPidSdJwtScheme -> EuPidSdJwtCredentialAttributeCategorization
             is MobileDrivingLicenceScheme -> MobileDrivingLicenceCredentialAttributeCategorization
             is PowerOfRepresentationScheme -> PowerOfRepresentationCredentialAttributeCategorization
             is CertificateOfResidenceScheme -> CertificateOfResidenceCredentialAttributeCategorization

--- a/shared/src/commonMain/kotlin/data/credentials/CredentialAttributeTranslator.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/CredentialAttributeTranslator.kt
@@ -4,6 +4,7 @@ import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.data.ConstantIndex
@@ -19,6 +20,7 @@ interface CredentialAttributeTranslator {
         operator fun get(scheme: ConstantIndex.CredentialScheme?) = when(scheme) {
             is IdAustriaScheme -> IdAustriaCredentialAttributeTranslator
             is EuPidScheme -> EuPidCredentialAttributeTranslator
+            is EuPidSdJwtScheme -> EuPidCredentialAttributeTranslator
             is MobileDrivingLicenceScheme -> MobileDrivingLicenceCredentialAttributeTranslator
             is PowerOfRepresentationScheme -> PowerOfRepresentationCredentialAttributeTranslator
             is CertificateOfResidenceScheme -> CertificateOfResidenceCredentialAttributeTranslator

--- a/shared/src/commonMain/kotlin/data/credentials/EuPidCredentialAttributeCategorization.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/EuPidCredentialAttributeCategorization.kt
@@ -5,6 +5,7 @@ package data.credentials
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.wallet.app.common.thirdParty.at.asitplus.jsonpath.core.plus
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import data.PersonalDataCategory
 
 object EuPidCredentialAttributeCategorization : CredentialAttributeCategorization.Template(
@@ -73,20 +74,20 @@ object EuPidCredentialAttributeCategorization : CredentialAttributeCategorizatio
     },
 )
 
-object EuPidCredentialSdJwtAttributeCategorization : CredentialAttributeCategorization.Template(
+object EuPidSdJwtCredentialAttributeCategorization : CredentialAttributeCategorization.Template(
     mapOf(
-        PersonalDataCategory.IdentityData to with(EuPidScheme.SdJwtAttributes) {
+        PersonalDataCategory.IdentityData to with(EuPidSdJwtScheme.SdJwtAttributes) {
             listOf(
                 GIVEN_NAME,
                 FAMILY_NAME,
                 BIRTH_DATE,
                 PORTRAIT,
                 NATIONALITIES,
-                GENDER,
+                SEX,
             ).map { NormalizedJsonPath() + it to null }
         },
 
-        PersonalDataCategory.AgeData to with(EuPidScheme.SdJwtAttributes) {
+        PersonalDataCategory.AgeData to with(EuPidSdJwtScheme.SdJwtAttributes) {
             listOf(
                 AGE_EQUAL_OR_OVER_12,
                 AGE_EQUAL_OR_OVER_14,
@@ -98,7 +99,7 @@ object EuPidCredentialSdJwtAttributeCategorization : CredentialAttributeCategori
             ).map { NormalizedJsonPath() + it to null }
         },
 
-        PersonalDataCategory.BirthData to with(EuPidScheme.SdJwtAttributes) {
+        PersonalDataCategory.BirthData to with(EuPidSdJwtScheme.SdJwtAttributes) {
             listOf(
                 GIVEN_NAME_BIRTH,
                 FAMILY_NAME_BIRTH,
@@ -108,7 +109,7 @@ object EuPidCredentialSdJwtAttributeCategorization : CredentialAttributeCategori
             ).map { NormalizedJsonPath() + it to null }
         },
 
-        PersonalDataCategory.ResidenceData to with(EuPidScheme.SdJwtAttributes) {
+        PersonalDataCategory.ResidenceData to with(EuPidSdJwtScheme.SdJwtAttributes) {
             listOf(
                 ADDRESS_STREET,
                 ADDRESS_HOUSE_NUMBER,
@@ -120,7 +121,7 @@ object EuPidCredentialSdJwtAttributeCategorization : CredentialAttributeCategori
             ).map { NormalizedJsonPath() + it to null }
         },
 
-        PersonalDataCategory.Metadata to with(EuPidScheme.SdJwtAttributes) {
+        PersonalDataCategory.Metadata to with(EuPidSdJwtScheme.SdJwtAttributes) {
             listOf(
                 DOCUMENT_NUMBER,
                 ISSUANCE_DATE,
@@ -128,12 +129,11 @@ object EuPidCredentialSdJwtAttributeCategorization : CredentialAttributeCategori
                 ISSUING_COUNTRY,
                 ISSUING_AUTHORITY,
                 ISSUING_JURISDICTION,
-                ADMINISTRATIVE_NUMBER,
                 PERSONAL_ADMINISTRATIVE_NUMBER,
             ).map { NormalizedJsonPath() + it to null }
         },
     ),
-    allAttributes = EuPidScheme.mapIsoToSdJwtAttributes.map {
-        NormalizedJsonPath() + it.value
+    allAttributes = EuPidSdJwtScheme.claimNames.map {
+        NormalizedJsonPath() + it
     },
 )

--- a/shared/src/commonMain/kotlin/data/credentials/EuPidCredentialAttributeTranslator.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/EuPidCredentialAttributeTranslator.kt
@@ -44,9 +44,10 @@ import at.asitplus.valera.resources.attribute_friendly_name_portrait
 import at.asitplus.valera.resources.attribute_friendly_name_sex
 import at.asitplus.valera.resources.attribute_friendly_name_trust_anchor
 import at.asitplus.wallet.eupid.EuPidScheme
-import at.asitplus.wallet.eupid.EuPidScheme.SdJwtAttributes.Address
-import at.asitplus.wallet.eupid.EuPidScheme.SdJwtAttributes.AgeEqualOrOver
-import at.asitplus.wallet.eupid.EuPidScheme.SdJwtAttributes.PlaceOfBirth
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme.SdJwtAttributes.Address
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme.SdJwtAttributes.AgeEqualOrOver
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme.SdJwtAttributes.PlaceOfBirth
 import org.jetbrains.compose.resources.StringResource
 
 
@@ -103,7 +104,7 @@ object EuPidCredentialAttributeTranslator : CredentialAttributeTranslator {
         }
     }
 
-    private fun withSdJwtNames(attributeName: NormalizedJsonPath) = with(EuPidScheme.SdJwtAttributes) {
+    private fun withSdJwtNames(attributeName: NormalizedJsonPath) = with(EuPidSdJwtScheme.SdJwtAttributes) {
         when (val first = attributeName.segments.firstOrNull()) {
             is NormalizedJsonPathSegment.NameSegment -> when (first.memberName) {
                 FAMILY_NAME -> Res.string.attribute_friendly_name_lastname
@@ -163,20 +164,18 @@ object EuPidCredentialAttributeTranslator : CredentialAttributeTranslator {
                 ADDRESS_POSTAL_CODE -> Res.string.attribute_friendly_name_main_residence_postal_code
                 ADDRESS_STREET -> Res.string.attribute_friendly_name_main_residence_street
                 ADDRESS_HOUSE_NUMBER -> Res.string.attribute_friendly_name_main_residence_house_number
-                GENDER -> Res.string.attribute_friendly_name_sex
+                SEX -> Res.string.attribute_friendly_name_sex
                 NATIONALITIES -> Res.string.attribute_friendly_name_nationality
                 ISSUANCE_DATE -> Res.string.attribute_friendly_name_issue_date
                 EXPIRY_DATE -> Res.string.attribute_friendly_name_expiry_date
                 ISSUING_AUTHORITY -> Res.string.attribute_friendly_name_issuing_authority
                 DOCUMENT_NUMBER -> Res.string.attribute_friendly_name_document_number
-                ADMINISTRATIVE_NUMBER -> Res.string.attribute_friendly_name_administrative_number
                 ISSUING_COUNTRY -> Res.string.attribute_friendly_name_issuing_country
                 ISSUING_JURISDICTION -> Res.string.attribute_friendly_name_issuing_jurisdiction
                 PERSONAL_ADMINISTRATIVE_NUMBER -> Res.string.attribute_friendly_name_personal_administrative_number
                 EMAIL -> Res.string.attribute_friendly_name_email_address
                 PHONE_NUMBER -> Res.string.attribute_friendly_name_mobile_phone_number
                 TRUST_ANCHOR -> Res.string.attribute_friendly_name_trust_anchor
-                LOCATION_STATUS -> Res.string.attribute_friendly_name_location_status
                 else -> null
             }
 

--- a/shared/src/commonMain/kotlin/data/credentials/Extensions.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/Extensions.kt
@@ -7,6 +7,7 @@ import at.asitplus.valera.resources.error_credential_scheme_not_supported
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
@@ -22,6 +23,7 @@ fun SubjectCredentialStore.StoreEntry.toCredentialAdapter(
     is CertificateOfResidenceScheme -> CertificateOfResidenceCredentialAdapter.createFromStoreEntry(this)
     is CompanyRegistrationScheme -> CompanyRegistrationCredentialAdapter.createFromStoreEntry(this)
     is EuPidScheme -> EuPidCredentialAdapter.createFromStoreEntry(this, decodePortrait = decodeImage)
+    is EuPidSdJwtScheme -> EuPidCredentialAdapter.createFromStoreEntry(this, decodePortrait = decodeImage)
     is HealthIdScheme -> HealthIdCredentialAdapter.createFromStoreEntry(this)
     is IdAustriaScheme -> IdAustriaCredentialAdapter.createFromStoreEntry(this, decodeImage = decodeImage)
     is MobileDrivingLicenceScheme -> MobileDrivingLicenceCredentialAdapter.createFromStoreEntry(this, decodePortrait = decodeImage)

--- a/shared/src/commonMain/kotlin/data/credentials/HealthIdCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/HealthIdCredentialAdapter.kt
@@ -5,6 +5,7 @@ import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.healthid.HealthIdScheme.Attributes
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import data.Attribute
 import kotlinx.datetime.Instant
@@ -70,6 +71,9 @@ sealed class HealthIdCredentialAdapter : CredentialAdapter() {
 private class HealthIdCredentialSdJwtAdapter(
     private val attributes: Map<String, JsonPrimitive>,
 ) : HealthIdCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = HealthIdScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -116,6 +120,9 @@ private class HealthIdCredentialSdJwtAdapter(
 private class HealthIdComplexCredentialSdJwtAdapter(
     private val attributes: JsonObject,
 ) : HealthIdCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = HealthIdScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -162,6 +169,9 @@ private class HealthIdComplexCredentialSdJwtAdapter(
 private class HealthIdCredentialIsoMdocAdapter(
     namespaces: Map<String, Map<String, Any>>?,
 ) : HealthIdCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = HealthIdScheme
+
     private val namespace = namespaces?.get(HealthIdScheme.isoNamespace)
 
     override val representation: CredentialRepresentation

--- a/shared/src/commonMain/kotlin/data/credentials/IdAustriaCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/IdAustriaCredentialAdapter.kt
@@ -7,6 +7,7 @@ import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.wallet.idaustria.IdAustriaCredential
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import data.Attribute
 import io.github.aakira.napier.Napier
@@ -124,6 +125,9 @@ private class IdAustriaCredentialVcAdapter(
     val credentialSubject: IdAustriaCredential,
     decodeImage: (ByteArray) -> ImageBitmap?,
 ) : IdAustriaCredentialAdapter(decodeImage) {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = IdAustriaScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.PLAIN_JWT
 
@@ -162,6 +166,9 @@ private class IdAustriaCredentialSdJwtAdapter(
     private val attributes: Map<String, JsonPrimitive>,
     decodeImage: (ByteArray) -> ImageBitmap?,
 ) : IdAustriaCredentialAdapter(decodeImage) {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = IdAustriaScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -200,6 +207,9 @@ private class IdAustriaCredentialIsoMdocAdapter(
     namespaces: Map<String, Map<String, Any>>?,
     decodeImage: (ByteArray) -> ImageBitmap?,
 ) : IdAustriaCredentialAdapter(decodeImage) {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = IdAustriaScheme
+
     private val idAustriaNamespace = namespaces?.get(IdAustriaScheme.isoNamespace)
 
     override val representation: CredentialRepresentation

--- a/shared/src/commonMain/kotlin/data/credentials/MobileDrivingLicenceCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/MobileDrivingLicenceCredentialAdapter.kt
@@ -5,6 +5,7 @@ import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.mdl.DrivingPrivilege
 import at.asitplus.wallet.mdl.IsoSexEnum
@@ -148,8 +149,11 @@ sealed class MobileDrivingLicenceCredentialAdapter(
 
 private class MobileDrivingLicenceCredentialSdJwtAdapter(
     private val attributes: Map<String, JsonPrimitive>,
-    private val decodePortrait: (ByteArray) -> ImageBitmap?,
+    decodePortrait: (ByteArray) -> ImageBitmap?,
 ) : MobileDrivingLicenceCredentialAdapter(decodePortrait) {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = MobileDrivingLicenceScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -269,6 +273,9 @@ private class MobileDrivingLicenceCredentialIsoMdocAdapter(
     namespaces: Map<String, Map<String, Any>>?,
     decodePortrait: (ByteArray) -> ImageBitmap?,
 ) : MobileDrivingLicenceCredentialAdapter(decodePortrait) {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = MobileDrivingLicenceScheme
+
     private val namespace = namespaces?.get(MobileDrivingLicenceScheme.isoNamespace)
 
     override val representation: CredentialRepresentation

--- a/shared/src/commonMain/kotlin/data/credentials/PowerOfRepresentationCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/PowerOfRepresentationCredentialAdapter.kt
@@ -3,6 +3,7 @@ package data.credentials
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.por.PowerOfRepresentationDataElements.ADMINISTRATIVE_NUMBER
 import at.asitplus.wallet.por.PowerOfRepresentationDataElements.DOCUMENT_NUMBER
@@ -83,6 +84,9 @@ sealed class PowerOfRepresentationCredentialAdapter : CredentialAdapter() {
 private class PowerOfRepresentationCredentialSdJwtAdapter(
     private val attributes: Map<String, JsonPrimitive>,
 ) : PowerOfRepresentationCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = PowerOfRepresentationScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -130,6 +134,9 @@ private class PowerOfRepresentationCredentialSdJwtAdapter(
 private class PowerOfRepresentationComplexSdJwtAdapter(
     private val attributes: JsonObject,
 ) : PowerOfRepresentationCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = PowerOfRepresentationScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 

--- a/shared/src/commonMain/kotlin/data/credentials/TaxIdCredentialAdapter.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/TaxIdCredentialAdapter.kt
@@ -3,6 +3,7 @@ package data.credentials
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.taxid.TaxIdScheme
 import at.asitplus.wallet.taxid.TaxIdScheme.Attributes.ADMINISTRATIVE_NUMBER
@@ -97,6 +98,9 @@ sealed class TaxIdCredentialAdapter : CredentialAdapter() {
 private class TaxIdCredentialSdJwtAdapter(
     private val attributes: Map<String, JsonPrimitive>,
 ) : TaxIdCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = TaxIdScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -155,6 +159,9 @@ private class TaxIdCredentialSdJwtAdapter(
 private class TaxIdComplexCredentialSdJwtAdapter(
     private val attributes: JsonObject,
 ) : TaxIdCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = TaxIdScheme
+
     override val representation: CredentialRepresentation
         get() = CredentialRepresentation.SD_JWT
 
@@ -213,6 +220,9 @@ private class TaxIdComplexCredentialSdJwtAdapter(
 private class TaxIdIsoMdocAdapter(
     namespaces: Map<String, Map<String, Any>>?,
 ) : TaxIdCredentialAdapter() {
+    override val scheme: ConstantIndex.CredentialScheme
+        get() = TaxIdScheme
+
     private val namespace = namespaces?.get(TaxIdScheme.isoNamespace)
 
     override val representation: CredentialRepresentation

--- a/shared/src/commonMain/kotlin/data/storage/PersistentSubjectCredentialStore.kt
+++ b/shared/src/commonMain/kotlin/data/storage/PersistentSubjectCredentialStore.kt
@@ -242,13 +242,14 @@ private sealed interface ExportableStoreEntry {
 }
 
 enum class ExportableCredentialScheme {
-    AtomicAttribute2023, IdAustriaScheme, MobileDrivingLicence2023, EuPidScheme, PowerOfRepresentationScheme, CertificateOfResidenceScheme, CompanyRegistrationScheme, HealthIdScheme, TaxIdScheme;
+    AtomicAttribute2023, IdAustriaScheme, MobileDrivingLicence2023, EuPidScheme, EuPidSdJwtScheme, PowerOfRepresentationScheme, CertificateOfResidenceScheme, CompanyRegistrationScheme, HealthIdScheme, TaxIdScheme;
 
     fun toScheme() = when (this) {
         AtomicAttribute2023 -> ConstantIndex.AtomicAttribute2023
         MobileDrivingLicence2023 -> MobileDrivingLicenceScheme
         IdAustriaScheme -> at.asitplus.wallet.idaustria.IdAustriaScheme
         EuPidScheme -> at.asitplus.wallet.eupid.EuPidScheme
+        EuPidSdJwtScheme -> at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
         PowerOfRepresentationScheme -> at.asitplus.wallet.por.PowerOfRepresentationScheme
         CertificateOfResidenceScheme -> at.asitplus.wallet.cor.CertificateOfResidenceScheme
         CompanyRegistrationScheme -> at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
@@ -262,6 +263,7 @@ enum class ExportableCredentialScheme {
             MobileDrivingLicenceScheme -> MobileDrivingLicence2023
             at.asitplus.wallet.idaustria.IdAustriaScheme -> IdAustriaScheme
             at.asitplus.wallet.eupid.EuPidScheme -> EuPidScheme
+            at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme -> EuPidSdJwtScheme
             at.asitplus.wallet.por.PowerOfRepresentationScheme -> PowerOfRepresentationScheme
             at.asitplus.wallet.cor.CertificateOfResidenceScheme -> CertificateOfResidenceScheme
             at.asitplus.wallet.companyregistration.CompanyRegistrationScheme -> CompanyRegistrationScheme

--- a/shared/src/commonMain/kotlin/ui/composables/DCQLCredentialQuerySubmissionSelectionOption.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/DCQLCredentialQuerySubmissionSelectionOption.kt
@@ -91,6 +91,7 @@ fun DCQLCredentialQuerySubmissionSelectionOption(
         }
 
         override val representation = credential.representation
+        override val scheme = credential.scheme!!
     }
     val labeledAttributes = genericAttributeList.mapNotNull { (key, value) ->
         credentialAdapter.getAttribute(key)?.let { attribute ->

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/CredentialSummaryCardContent.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/CredentialSummaryCardContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
@@ -20,6 +21,7 @@ fun CredentialSummaryCardContent(
     when (credential.scheme) {
         is IdAustriaScheme -> IdAustriaCredentialSummaryCardContent(credential, decodeToBitmap)
         is EuPidScheme -> EuPidCredentialSummaryCardContent(credential, decodeToBitmap)
+        is EuPidSdJwtScheme -> EuPidCredentialSummaryCardContent(credential, decodeToBitmap)
         is MobileDrivingLicenceScheme -> MobileDrivingLicenceCredentialSummaryCardContent(credential, decodeToBitmap)
         is PowerOfRepresentationScheme -> PowerOfRepresentationCredentialSummaryCardContent(credential)
         is CertificateOfResidenceScheme -> CertificateOfResidenceCredentialSummaryCardContent(credential)

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialAgeDataCard.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialAgeDataCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import at.asitplus.wallet.eupid.EuPidScheme
 import data.PersonalDataCategory
 import data.credentials.EuPidCredentialAdapter
 import ui.composables.AttributeRepresentation
@@ -23,7 +22,7 @@ fun EuPidCredentialAgeDataCard(
     modifier: Modifier = Modifier,
 ) {
     CredentialDetailCard(
-        credentialScheme = EuPidScheme,
+        credentialScheme = credentialAdapter.scheme,
         personalDataCategory = PersonalDataCategory.AgeData,
         credentialAdapter = credentialAdapter,
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialBirthdataDataCard.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialBirthdataDataCard.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
-import at.asitplus.wallet.eupid.EuPidScheme
 import data.PersonalDataCategory
 import data.credentials.EuPidCredentialAdapter
 import ui.composables.AttributeRepresentation
@@ -27,7 +26,7 @@ fun EuPidCredentialBirthdataDataCard(
     modifier: Modifier = Modifier,
 ) {
     CredentialDetailCard(
-        credentialScheme = EuPidScheme,
+        credentialScheme = credentialAdapter.scheme,
         personalDataCategory = PersonalDataCategory.BirthData,
         credentialAdapter = credentialAdapter,
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialIdentityDataCard.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialIdentityDataCard.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.content_description_portrait
-import at.asitplus.wallet.eupid.EuPidScheme
 import data.PersonalDataCategory
 import data.credentials.EuPidCredentialAdapter
 import org.jetbrains.compose.resources.stringResource
@@ -34,7 +33,7 @@ fun EuPidCredentialIdentityDataCard(
     modifier: Modifier = Modifier,
 ) {
     CredentialDetailCard(
-        credentialScheme = EuPidScheme,
+        credentialScheme = credentialAdapter.scheme,
         personalDataCategory = PersonalDataCategory.IdentityData,
         credentialAdapter = credentialAdapter,
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialMetadataCard.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialMetadataCard.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
-import at.asitplus.wallet.eupid.EuPidScheme
 import data.PersonalDataCategory
 import data.credentials.EuPidCredentialAdapter
 import ui.composables.AttributeRepresentation
@@ -27,7 +26,7 @@ fun EuPidCredentialMetadataCard(
     modifier: Modifier = Modifier,
 ) {
     CredentialDetailCard(
-        credentialScheme = EuPidScheme,
+        credentialScheme = credentialAdapter.scheme,
         personalDataCategory = PersonalDataCategory.Metadata,
         credentialAdapter = credentialAdapter,
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialResidenceDataCard.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/EuPidCredentialResidenceDataCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import at.asitplus.wallet.eupid.EuPidScheme
 import data.PersonalDataCategory
 import data.credentials.EuPidCredentialAdapter
 import ui.composables.AttributeRepresentation
@@ -17,7 +16,7 @@ fun EuPidCredentialResidenceDataCard(
     modifier: Modifier = Modifier,
 ) {
     CredentialDetailCard(
-        credentialScheme = EuPidScheme,
+        credentialScheme = credentialAdapter.scheme,
         personalDataCategory = PersonalDataCategory.ResidenceData,
         credentialAdapter = credentialAdapter,
         modifier = modifier,

--- a/shared/src/commonMain/kotlin/ui/views/CredentialDetailsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/CredentialDetailsView.kt
@@ -29,6 +29,7 @@ import at.asitplus.valera.resources.heading_label_credential_details_screen
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import at.asitplus.wallet.healthid.HealthIdScheme
 import at.asitplus.wallet.idaustria.IdAustriaScheme
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
@@ -137,6 +138,7 @@ fun CredentialDetailsSummaryView(
         when (storeEntry.scheme) {
             is IdAustriaScheme -> IdAustriaCredentialView(storeEntry, imageDecoder)
             is EuPidScheme -> EuPidCredentialView(storeEntry, imageDecoder)
+            is EuPidSdJwtScheme -> EuPidCredentialView(storeEntry, imageDecoder)
             is MobileDrivingLicenceScheme -> MobileDrivingLicenceCredentialView(storeEntry, imageDecoder)
             is PowerOfRepresentationScheme -> PowerOfRepresentationCredentialView(storeEntry)
             is CertificateOfResidenceScheme -> CertificateOfResidenceCredentialView(storeEntry)


### PR DESCRIPTION
ARF 1.8.0 did change the SD-JWT claim names, as well as the `vct` value ... since this is a unique identifier, and we don't want to break existing implementations using the old value, we've created <https://github.com/a-sit-plus/eu-pid-credential-sdjwt/tree/main>. This PR adds support for that scheme in Valera.