### PR TITLE
Full-Screen View for completed presentation

### DIFF
--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -273,6 +273,7 @@
     <string name="heading_label_select_vda">VDA auswählen</string>
     <string name="heading_label_sign">Signieren</string>
     <string name="heading_label_tech_demo">Tech Demo</string>
+    <string name="heading_label_result">Ergebnis</string>
 
     <string name="biometric_authentication_prompt_for_data_transmission_consent_title">Biometrische Authentifizierung</string>
     <string name="biometric_authentication_prompt_for_data_transmission_consent_subtitle">Daten vorzeigen</string>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -270,6 +270,7 @@
     <string name="heading_label_check_scan_qr_code">Scan QR-Code</string>
     <string name="heading_label_show_qr_code_screen">Scan me!</string>
     <string name="heading_label_received_data">Received Data</string>
+    <string name="heading_label_result">Result</string>
 
     <string name="heading_label_select_vda">Select VDA</string>
     <string name="heading_label_sign">Sign</string>

--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -113,7 +113,7 @@ import ui.views.OnboardingInformationView
 import ui.views.OnboardingStartView
 import ui.views.PreAuthQrCodeScannerScreen
 import ui.views.PresentDataView
-import ui.views.PresentationView
+import ui.views.presentation.PresentationView
 import ui.views.SelectIssuingServerView
 import ui.views.SettingsView
 import ui.views.SigningQtspSelectionView

--- a/shared/src/commonMain/kotlin/ui/views/presentation/PresentationCompletedView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/presentation/PresentationCompletedView.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.asitplus.valera.resources.Res
+import at.asitplus.valera.resources.heading_label_result
 import at.asitplus.valera.resources.icon_presentation_error
 import at.asitplus.valera.resources.icon_presentation_success
 import at.asitplus.valera.resources.presentation_canceled
@@ -41,7 +42,7 @@ fun PresentationCompletedView(error: Throwable?) {
                 title = {
                     Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            text = "Result",
+                            text = stringResource(Res.string.heading_label_result),
                             modifier = Modifier.weight(1f),
                             style = MaterialTheme.typography.headlineMedium,
                         )

--- a/shared/src/commonMain/kotlin/ui/views/presentation/PresentationCompletedView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/presentation/PresentationCompletedView.kt
@@ -1,0 +1,109 @@
+package ui.views.presentation
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import at.asitplus.valera.resources.Res
+import at.asitplus.valera.resources.icon_presentation_error
+import at.asitplus.valera.resources.icon_presentation_success
+import at.asitplus.valera.resources.presentation_canceled
+import at.asitplus.valera.resources.presentation_error
+import at.asitplus.valera.resources.presentation_success
+import at.asitplus.valera.resources.presentation_timeout
+import at.asitplus.wallet.app.common.presentation.PresentmentCanceled
+import at.asitplus.wallet.app.common.presentation.PresentmentTimeout
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PresentationCompletedView(error: Throwable?) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = "Result",
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.headlineMedium,
+                        )
+                    }
+                }
+            )
+        }
+    ) { scaffoldPadding ->
+        Column(
+            modifier = Modifier.padding(scaffoldPadding).fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            when (error) {
+                null -> showPresentationSuccess()
+                else -> showPresentationFailure(error)
+            }
+        }
+    }
+}
+
+@Composable
+fun showPresentationSuccess() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        showImageAndText(
+            painterResource(Res.drawable.icon_presentation_success),
+            stringResource(Res.string.presentation_success)
+        )
+    }
+}
+
+@Composable
+fun showPresentationFailure(error: Throwable) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        val text = when (error) {
+            is PresentmentCanceled -> stringResource(Res.string.presentation_canceled)
+            is PresentmentTimeout -> stringResource(Res.string.presentation_timeout)
+            else -> stringResource(Res.string.presentation_error)
+        }
+        showImageAndText(painterResource(Res.drawable.icon_presentation_error), text)
+    }
+}
+
+@Composable
+fun showImageAndText(painter: Painter, text: String) {
+    Image(
+        modifier = Modifier.size(200.dp).fillMaxSize().padding(10.dp),
+        painter = painter,
+        contentDescription = null,
+        contentScale = ContentScale.Fit,
+    )
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyLarge,
+        fontWeight = FontWeight.Normal
+    )
+}

--- a/shared/src/commonMain/kotlin/ui/views/presentation/PresentationView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/presentation/PresentationView.kt
@@ -1,50 +1,35 @@
 package ui.views.presentation
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.asitplus.valera.resources.Res
-import at.asitplus.valera.resources.icon_presentation_error
-import at.asitplus.valera.resources.icon_presentation_success
-import at.asitplus.valera.resources.presentation_canceled
 import at.asitplus.valera.resources.presentation_connecting_to_verifier
-import at.asitplus.valera.resources.presentation_error
 import at.asitplus.valera.resources.presentation_initialised
 import at.asitplus.valera.resources.presentation_missing_permission
 import at.asitplus.valera.resources.presentation_permission_required
-import at.asitplus.valera.resources.presentation_success
-import at.asitplus.valera.resources.presentation_timeout
 import at.asitplus.valera.resources.presentation_waiting_for_request
 import at.asitplus.wallet.app.common.SnackbarService
 import at.asitplus.wallet.app.common.presentation.MdocPresentmentMechanism
-import at.asitplus.wallet.app.common.presentation.PresentmentCanceled
-import at.asitplus.wallet.app.common.presentation.PresentmentTimeout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.permissions.rememberBluetoothPermissionState
 import ui.viewmodels.authentication.AuthenticationConsentViewModel
@@ -95,9 +80,7 @@ fun PresentationView(
     // all BLE and NFC resources.
     //
     DisposableEffect(presentationStateModel) {
-        onDispose {
-            presentationStateModel.reset()
-        }
+        onDispose { presentationStateModel.reset() }
     }
 
     val state = presentationStateModel.state.collectAsState().value
@@ -105,8 +88,7 @@ fun PresentationView(
         PresentationStateModel.State.IDLE,
         PresentationStateModel.State.NO_PERMISSION,
         PresentationStateModel.State.INITIALISING,
-        PresentationStateModel.State.CONNECTING -> {
-        }
+        PresentationStateModel.State.CONNECTING -> {}
 
         PresentationStateModel.State.CHECK_PERMISSIONS -> {
             if (blePermissionState.isGranted) {
@@ -228,20 +210,9 @@ fun PresentationView(
                     }
                 )
 
-                PresentationStateModel.State.COMPLETED -> {
-                    when (presentationStateModel.error) {
-                        null -> showPresentationSuccess()
-
-                        is PresentmentCanceled ->
-                            showPresentationFailure(stringResource(Res.string.presentation_canceled))
-
-                        is PresentmentTimeout ->
-                            showPresentationFailure(stringResource(Res.string.presentation_timeout))
-
-                        else ->
-                            showPresentationFailure(stringResource(Res.string.presentation_error))
-                    }
-                }
+                PresentationStateModel.State.COMPLETED -> PresentationCompletedView(
+                    presentationStateModel.error
+                )
 
                 PresentationStateModel.State.WAITING_FOR_DOCUMENT_SELECTION ->
                     throw IllegalStateException("should not be reachable")
@@ -291,44 +262,4 @@ fun PresentationView(
             )
         }
     }
-}
-
-@Composable
-fun showPresentationSuccess() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        showImageAndText(
-            painterResource(Res.drawable.icon_presentation_success),
-            stringResource(Res.string.presentation_success)
-        )
-    }
-}
-
-@Composable
-fun showPresentationFailure(text: String) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        showImageAndText(painterResource(Res.drawable.icon_presentation_error), text)
-    }
-}
-
-@Composable
-fun showImageAndText(painter: Painter, text: String) {
-    Image(
-        modifier = Modifier.size(200.dp).fillMaxSize().padding(10.dp),
-        painter = painter,
-        contentDescription = null,
-        contentScale = ContentScale.Fit,
-    )
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodyLarge,
-        fontWeight = FontWeight.Normal
-    )
 }

--- a/shared/src/commonMain/kotlin/ui/views/presentation/PresentationView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/presentation/PresentationView.kt
@@ -108,32 +108,32 @@ fun PresentationView(
         PresentationStateModel.State.WAITING_FOR_DOCUMENT_SELECTION -> {
             when (presentationViewModel.viewState) {
                 AuthenticationViewState.Consent -> {
-                    val viewModel = AuthenticationConsentViewModel(
-                        spName = presentationViewModel.spName,
-                        spLocation = presentationViewModel.spLocation,
-                        spImage = presentationViewModel.spImage,
-                        transactionData = presentationViewModel.transactionData,
-                        navigateUp = presentationViewModel.navigateUp,
-                        buttonConsent = {
-                            CoroutineScope(Dispatchers.IO).launch {
-                                presentationViewModel.onConsent()
-                            }
-                        },
-                        walletMain = presentationViewModel.walletMain,
-                        presentationRequest = presentationViewModel.presentationRequest,
-                        onClickLogo = presentationViewModel.onClickLogo,
-                        onClickSettings = presentationViewModel.onClickSettings
-                    )
                     AuthenticationConsentView(
-                        viewModel,
-                        onError = onError,
+                        vm = AuthenticationConsentViewModel(
+                            spName = presentationViewModel.spName,
+                            spLocation = presentationViewModel.spLocation,
+                            spImage = presentationViewModel.spImage,
+                            transactionData = presentationViewModel.transactionData,
+                            navigateUp = presentationViewModel.navigateUp,
+                            buttonConsent = {
+                                CoroutineScope(Dispatchers.IO).launch {
+                                    presentationViewModel.onConsent()
+                                }
+                            },
+                            walletMain = presentationViewModel.walletMain,
+                            presentationRequest = presentationViewModel.presentationRequest,
+                            onClickLogo = presentationViewModel.onClickLogo,
+                            onClickSettings = presentationViewModel.onClickSettings
+                        ),
+                        onError = onError
                     )
                 }
 
                 AuthenticationViewState.NoMatchingCredential -> {
-                    val viewModel =
-                        AuthenticationNoCredentialViewModel(navigateToHomeScreen = presentationViewModel.navigateToHomeScreen)
-                    AuthenticationNoCredentialView(vm = viewModel)
+                    AuthenticationNoCredentialView(AuthenticationNoCredentialViewModel(
+                            navigateToHomeScreen = presentationViewModel.navigateToHomeScreen
+                        )
+                    )
                 }
 
                 AuthenticationViewState.Selection -> {
@@ -155,17 +155,16 @@ fun PresentationView(
                         }
 
                         is PresentationExchangeMatchingResult -> {
-                            val viewModel = AuthenticationSelectionPresentationExchangeViewModel(
-                                walletMain = presentationViewModel.walletMain,
-                                confirmSelections = { selections ->
-                                    presentationViewModel.confirmSelection(selections)
-                                },
-                                navigateUp = { presentationViewModel.viewState = AuthenticationViewState.Consent },
-                                credentialMatchingResult = matching,
-                                navigateToHomeScreen = presentationViewModel.navigateToHomeScreen
-                            )
                             AuthenticationSelectionPresentationExchangeView(
-                                vm = viewModel,
+                                vm = AuthenticationSelectionPresentationExchangeViewModel(
+                                    walletMain = presentationViewModel.walletMain,
+                                    confirmSelections = { selections ->
+                                        presentationViewModel.confirmSelection(selections)
+                                    },
+                                    navigateUp = { presentationViewModel.viewState = AuthenticationViewState.Consent },
+                                    credentialMatchingResult = matching,
+                                    navigateToHomeScreen = presentationViewModel.navigateToHomeScreen
+                                ),
                                 onError = onError,
                                 onClickLogo = presentationViewModel.onClickLogo,
                                 onClickSettings = presentationViewModel.onClickSettings,

--- a/shared/src/commonMain/kotlin/ui/views/presentation/PresentationView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/presentation/PresentationView.kt
@@ -1,4 +1,4 @@
-package ui.views
+package ui.views.presentation
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -55,6 +55,7 @@ import ui.viewmodels.authentication.DCQLMatchingResult
 import ui.viewmodels.authentication.PresentationExchangeMatchingResult
 import ui.viewmodels.authentication.PresentationStateModel
 import ui.viewmodels.authentication.PresentationViewModel
+import ui.views.LoadingView
 import ui.views.authentication.AuthenticationConsentView
 import ui.views.authentication.AuthenticationNoCredentialView
 import ui.views.authentication.AuthenticationSelectionPresentationExchangeView


### PR DESCRIPTION
- Display a full-screen `PresentationCompletedView`
- On success:
    - Show a success icon.
    - Display a success message/description.
- On failure:
    - Show a failure icon.
    - Display a failure reason/message.
- Cleanup for `PresentationView`

![Screenshot_20250512-111826](https://github.com/user-attachments/assets/927b8eb8-e687-4ef6-83be-a0e66effe402)
("Result" is translated to "Ergebnis" now)