### PR TITLE
Optimize task 'iosBootSimulator' 

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -165,10 +165,12 @@ exportXCFramework(
 }
 
 tasks.register("iosBootSimulator"){
-    exec {
-        isIgnoreExitValue = true
-        runCatching {
-            commandLine("xcrun", "simctl", "boot", "iPhone 16")
+    doLast {
+        exec {
+            isIgnoreExitValue = true
+            runCatching {
+                commandLine("xcrun", "simctl", "boot", "iPhone 16")
+            }
         }
     }
 }


### PR DESCRIPTION
- Add doLast (Task would otherwise run as early as the gradle parsing)
