### PR TITLE
Supercharge CI/CD with caching

### DIFF
--- a/.github/workflows/cache-android.yml
+++ b/.github/workflows/cache-android.yml
@@ -1,0 +1,29 @@
+name: Android cache workflow
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Cache gradle
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-gradle
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: Android-${{ hashFiles('./gradle/libs.versions.toml', './gradle.properties') }}
+      - name: Build project
+        run: ./gradlew :androidApp:assembleDebug
+        env:
+          ANDROID_CERT_PASSWORD: ${{ secrets.ANDROID_CERT_PASSWORD }}
+          CI: true

--- a/.github/workflows/cache-ios.yml
+++ b/.github/workflows/cache-ios.yml
@@ -1,0 +1,29 @@
+name: iOS cache workflow
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Cache gradle
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-gradle
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: iOS-${{ hashFiles('./gradle/libs.versions.toml', './gradle.properties') }}
+      - name: Run shared tests
+        run: ./gradlew :shared:iosSimulatorArm64Test

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Cache gradle
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-gradle
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: iOS-${{ hashFiles('./gradle/libs.versions.toml', './gradle.properties') }}
       - name: Run UI tests
         run: |
           xcodebuild \

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -12,6 +13,15 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Cache gradle
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-gradle
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: Android-${{ hashFiles('./gradle/libs.versions.toml', './gradle.properties') }}
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules


### PR DESCRIPTION
- Add caching to existing test workflows
- Create new `workflow_dispatch` to manually trigger caching
- Cap all workflows (except release workflows) to 30m