### PR TITLE
Show all requested data on consent screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release 5.7.4 (unreleased):
-
+ * Presentation: Always show requested attributes
 
 # Release 5.7.3
  * Update to VC-K 5.8.0, fixing optional attributes during presentation

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/dcapi/data/preview/IdentityCredentialField.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/dcapi/data/preview/IdentityCredentialField.kt
@@ -30,11 +30,11 @@ data class IdentityCredentialField(
 
         suspend fun fromNamespaceAttributeMap(
             attributeMap: Map<String, Map<String, Any>>,
-            attributeTranslator: CredentialAttributeTranslator
+            attributeTranslator: CredentialAttributeTranslator?
         ): List<IdentityCredentialField> = attributeMap.flatMap { (namespace, valuePair) ->
             valuePair.map { (name, value) ->
                 val entryName = "$namespace.$name"
-                val displayName = attributeTranslator.translate(name.toJsonPath())?.let { getString(it) } ?: name
+                val displayName = attributeTranslator?.translate(name.toJsonPath())?.let { getString(it) } ?: name
                 val serializedValue = value.toString().safeSubstring(128) //TODO toString() is a hack
                 IdentityCredentialField(entryName, serializedValue, displayName, serializedValue)
             }
@@ -47,9 +47,9 @@ data class IdentityCredentialField(
         // TODO untested
         suspend fun fromAttributeMap(
             attributeMap: Map<String, JsonPrimitive>,
-            attributeTranslator: CredentialAttributeTranslator
+            attributeTranslator: CredentialAttributeTranslator?
         ): List<IdentityCredentialField> = attributeMap.map { (name, value) ->
-            val displayName = attributeTranslator.translate(name.toJsonPath())?.let { getString(it) } ?: name
+            val displayName = attributeTranslator?.translate(name.toJsonPath())?.let { getString(it) } ?: name
             val serializedValue = value.toString().safeSubstring(128) //TODO toString() is a hack
             IdentityCredentialField(name, serializedValue, displayName, serializedValue)
         }

--- a/shared/src/commonMain/kotlin/data/credentials/Extensions.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/Extensions.kt
@@ -2,8 +2,10 @@ package data.credentials
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
+import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.error_credential_scheme_not_supported
+import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.agent.representation
 import at.asitplus.wallet.companyregistration.CompanyRegistrationScheme
 import at.asitplus.wallet.cor.CertificateOfResidenceScheme
 import at.asitplus.wallet.eupid.EuPidScheme
@@ -14,6 +16,7 @@ import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.mdl.MobileDrivingLicenceScheme
 import at.asitplus.wallet.por.PowerOfRepresentationScheme
 import at.asitplus.wallet.taxid.TaxIdScheme
+import data.Attribute
 import org.jetbrains.compose.resources.stringResource
 
 @Suppress("DEPRECATION")
@@ -30,6 +33,20 @@ fun SubjectCredentialStore.StoreEntry.toCredentialAdapter(
     is MobileDrivingLicenceScheme -> MobileDrivingLicenceCredentialAdapter.createFromStoreEntry(this, decodePortrait = decodeImage)
     is PowerOfRepresentationScheme -> PowerOfRepresentationCredentialAdapter.createFromStoreEntry(this)
     is TaxIdScheme -> TaxIdCredentialAdapter.createFromStoreEntry(this)
-    null -> null
-    else -> throw IllegalStateException(stringResource(Res.string.error_credential_scheme_not_supported))
+    else -> null
+}
+
+
+class FallbackCredentialAdapter(
+    genericAttributeList: List<Pair<NormalizedJsonPath, Any>>,
+    val credential: SubjectCredentialStore.StoreEntry
+) : CredentialAdapter() {
+    // trying our best to map the values to attributes
+    private val mapping = genericAttributeList.toMap()
+
+    override fun getAttribute(path: NormalizedJsonPath): Attribute? = mapping[path]
+        ?.let { Attribute.fromValue(it) }
+
+    override val representation = credential.representation
+    override val scheme = credential.scheme!!
 }

--- a/shared/src/commonMain/kotlin/ui/composables/DCQLCredentialQuerySubmissionSelectionOption.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/DCQLCredentialQuerySubmissionSelectionOption.kt
@@ -28,6 +28,7 @@ import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import data.Attribute
 import data.credentials.CredentialAdapter
+import data.credentials.FallbackCredentialAdapter
 import data.credentials.toCredentialAdapter
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
@@ -78,19 +79,8 @@ fun DCQLCredentialQuerySubmissionSelectionOption(
         }
     }
 
-    val credentialAdapter = credential.toCredentialAdapter(decodeToBitmap) ?: object : CredentialAdapter() {
-        // trying our best to map the values to attributes
-        private val mapping = genericAttributeList.toMap()
-
-        override fun getAttribute(path: NormalizedJsonPath): Attribute? {
-            return mapping[path]?.let {
-                Attribute.fromValue(it)
-            }
-        }
-
-        override val representation = credential.representation
-        override val scheme = credential.scheme!!
-    }
+    val credentialAdapter = credential.toCredentialAdapter(decodeToBitmap)
+        ?: FallbackCredentialAdapter(genericAttributeList, credential)
     val labeledAttributes = genericAttributeList.mapNotNull { (key, value) ->
         credentialAdapter.getAttribute(key)?.let { attribute ->
             key.segments.lastOrNull()?.let {

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/GenericDataCardContent.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/GenericDataCardContent.kt
@@ -26,9 +26,9 @@ fun GenericDataCardContent(
         attributes.mapIndexed { index, it ->
             LabeledContent(
                 label = CredentialAttributeTranslator[credentialScheme]
-                    ?.translate(it.first)?.let {
-                        stringResource(it)
-                    } ?: it.first.toString(),
+                    ?.translate(it.first)
+                    ?.let { stringResource(it) }
+                    ?: it.first.toString(),
                 content = it.second,
                 modifier = if (index == attributes.lastIndex) {
                     Modifier

--- a/shared/src/commonMain/kotlin/ui/viewmodels/authentication/AuthenticationViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/authentication/AuthenticationViewModel.kt
@@ -17,6 +17,7 @@ import at.asitplus.wallet.lib.ktor.openid.OpenId4VpWallet
 import at.asitplus.wallet.lib.openid.CredentialMatchingResult
 import at.asitplus.wallet.lib.openid.DCQLMatchingResult
 import at.asitplus.wallet.lib.openid.PresentationExchangeMatchingResult
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
 
@@ -44,6 +45,7 @@ abstract class AuthenticationViewModel(
     suspend fun onConsent() {
         matchingCredentials = findMatchingCredentials().getOrElse {
             viewState = AuthenticationViewState.NoMatchingCredential
+            Napier.w("No matching credential", it)
             return
         }
 


### PR DESCRIPTION
Try to show as much data from presentation requests as possible on the first "consent" screen, so the user sees which credential type is requested (even if we don't know a `CredentialScheme` for it), and also all attributes requested (even if the stored credential doesn't feature it, or we don't know about that claim name at all).