### PR TITLE
Fix proximity capability check

### DIFF
--- a/shared/src/androidMain/kotlin/at/asitplus/wallet/app/android/iso/transfer/NfcInfo.android.kt
+++ b/shared/src/androidMain/kotlin/at/asitplus/wallet/app/android/iso/transfer/NfcInfo.android.kt
@@ -1,0 +1,40 @@
+package at.asitplus.wallet.app.common.iso.transfer
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.nfc.NfcAdapter
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
+
+
+actual class NfcInfo {
+    @Composable
+    actual fun isNfcEnabled(): Boolean {
+        val context = LocalContext.current
+        val nfcAdapter = remember { NfcAdapter.getDefaultAdapter(context) }
+        val initialState = nfcAdapter?.isEnabled == true
+        val state = remember { mutableStateOf(initialState) }
+
+        DisposableEffect(context) {
+            val receiver = object : BroadcastReceiver() {
+                override fun onReceive(ctx: Context?, intent: Intent?) {
+                    if (intent?.action == NfcAdapter.ACTION_ADAPTER_STATE_CHANGED) {
+                        val newState = nfcAdapter?.isEnabled == true
+                        state.value = newState
+                    }
+                }
+            }
+
+            val filter = IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
+            context.registerReceiver(receiver, filter)
+
+            onDispose {
+                context.unregisterReceiver(receiver)
+            }
+        }
+
+        return state.value
+    }
+}

--- a/shared/src/androidMain/kotlin/at/asitplus/wallet/app/android/iso/transfer/NfcInfo.android.kt
+++ b/shared/src/androidMain/kotlin/at/asitplus/wallet/app/android/iso/transfer/NfcInfo.android.kt
@@ -4,37 +4,33 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import android.nfc.NfcAdapter
-import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
-
 
 actual class NfcInfo {
     @Composable
     actual fun isNfcEnabled(): Boolean {
         val context = LocalContext.current
         val nfcAdapter = remember { NfcAdapter.getDefaultAdapter(context) }
-        val initialState = nfcAdapter?.isEnabled == true
-        val state = remember { mutableStateOf(initialState) }
+        val isNfcEnabled = remember { mutableStateOf(nfcAdapter?.isEnabled == true) }
 
         DisposableEffect(context) {
             val receiver = object : BroadcastReceiver() {
                 override fun onReceive(ctx: Context?, intent: Intent?) {
                     if (intent?.action == NfcAdapter.ACTION_ADAPTER_STATE_CHANGED) {
-                        val newState = nfcAdapter?.isEnabled == true
-                        state.value = newState
+                        val currentAdapter = NfcAdapter.getDefaultAdapter(context)
+                        isNfcEnabled.value = currentAdapter?.isEnabled == true
                     }
                 }
             }
-
             val filter = IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
             context.registerReceiver(receiver, filter)
-
-            onDispose {
-                context.unregisterReceiver(receiver)
-            }
+            onDispose { context.unregisterReceiver(receiver) }
         }
-
-        return state.value
+        return isNfcEnabled.value
     }
 }

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -324,6 +324,7 @@
     <string name="error_missing_permissions">Fehlende Erlaubnis</string>
     <string name="error_missing_value">Fehler es sind keine Daten gegeben</string>
     <string name="error_bluetooth_unavailable">Bluetooth ist nicht verfügbar</string>
+    <string name="error_bluetooth_and_nfc_unavailable">Weder Bluetooth noch NFC ist verfügbar</string>
     <string name="error_no_requests">Es sind keine Anfragen vorhanden</string>
 
     <string name="info_text_show_data_situation">In welcher Situation möchten Sie Ihre Daten vorzeigen?</string>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -325,6 +325,7 @@
     <string name="error_missing_permissions">Permission Denied</string>
     <string name="error_missing_value">Error no value given</string>
     <string name="error_bluetooth_unavailable">Bluetooth is not available</string>
+    <string name="error_bluetooth_and_nfc_unavailable">Neither Bluetooth nor NFC is available</string>
     <string name="error_no_requests">No requests found</string>
 
     <string name="info_text_show_data_situation">In which Situation do you want to present your data?</string>

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/CapabilityManager.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/CapabilityManager.kt
@@ -2,7 +2,7 @@ package at.asitplus.wallet.app.common.iso.transfer
 
 import androidx.compose.runtime.Composable
 
-class CapabilityManager() {
+object CapabilityManager {
     private val bluetoothInfo = BluetoothInfo()
     private val nfcInfo = NfcInfo()
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/CapabilityManager.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/CapabilityManager.kt
@@ -1,0 +1,23 @@
+package at.asitplus.wallet.app.common.iso.transfer
+
+import androidx.compose.runtime.Composable
+
+class CapabilityManager() {
+    private val bluetoothInfo = BluetoothInfo()
+    private val nfcInfo = NfcInfo()
+
+    @Composable
+    fun isBluetoothEnabled(): Boolean {
+        return bluetoothInfo.isBluetoothEnabled()
+    }
+
+    @Composable
+    fun isNfcEnabled(): Boolean {
+        return nfcInfo.isNfcEnabled()
+    }
+
+    @Composable
+    fun isAnyTransferMethodAvailable(): Boolean {
+        return (isBluetoothEnabled() || isNfcEnabled())
+    }
+}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/NfcInfo.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/NfcInfo.kt
@@ -1,0 +1,8 @@
+package at.asitplus.wallet.app.common.iso.transfer
+
+import androidx.compose.runtime.Composable
+
+expect class NfcInfo() {
+    @Composable
+    fun isNfcEnabled(): Boolean
+}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/TransferCapablities.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/TransferCapablities.kt
@@ -1,0 +1,8 @@
+package at.asitplus.wallet.app.common.iso.transfer
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun isAnyTransferMethodAvailable(): Boolean {
+    return (BluetoothInfo().isBluetoothEnabled() || NfcInfo().isNfcEnabled())
+}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/TransferCapablities.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/TransferCapablities.kt
@@ -1,8 +1,0 @@
-package at.asitplus.wallet.app.common.iso.transfer
-
-import androidx.compose.runtime.Composable
-
-@Composable
-fun isAnyTransferMethodAvailable(): Boolean {
-    return (BluetoothInfo().isBluetoothEnabled() || NfcInfo().isNfcEnabled())
-}

--- a/shared/src/commonMain/kotlin/ui/viewmodels/iso/ShowQrCodeViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/iso/ShowQrCodeViewModel.kt
@@ -128,7 +128,7 @@ class ShowQrCodeViewModel(
 
 enum class ShowQrCodeState {
     INIT,
-    BLUETOOTH_DISABLED,
+    NO_TRANSFER_METHOD_AVAILABLE,
     MISSING_PERMISSION,
     CREATE_ENGAGEMENT,
     SHOW_QR_CODE,

--- a/shared/src/commonMain/kotlin/ui/views/iso/ShowQrCodeView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/iso/ShowQrCodeView.kt
@@ -36,8 +36,8 @@ import at.asitplus.valera.resources.error_bluetooth_and_nfc_unavailable
 import at.asitplus.valera.resources.error_missing_permissions
 import at.asitplus.valera.resources.heading_label_show_qr_code_screen
 import at.asitplus.valera.resources.info_text_qr_code_loading
+import at.asitplus.wallet.app.common.iso.transfer.CapabilityManager
 import at.asitplus.wallet.app.common.iso.transfer.MdocConstants.MDOC_PREFIX
-import at.asitplus.wallet.app.common.iso.transfer.isAnyTransferMethodAvailable
 import io.github.alexzhirkevich.qrose.options.QrBrush
 import io.github.alexzhirkevich.qrose.options.QrColors
 import io.github.alexzhirkevich.qrose.options.solid
@@ -63,6 +63,7 @@ fun ShowQrCodeView(vm: ShowQrCodeViewModel) {
     val showQrCode = remember { mutableStateOf<ByteString?>(null) }
     val presentationStateModel = remember { vm.presentationStateModel }
     val showQrCodeState by vm.showQrCodeState.collectAsState()
+    val capabilityManager = CapabilityManager()
 
     Scaffold(
         topBar = {
@@ -96,7 +97,7 @@ fun ShowQrCodeView(vm: ShowQrCodeViewModel) {
             ) {
                 when (showQrCodeState) {
                     ShowQrCodeState.INIT -> {
-                        if (!isAnyTransferMethodAvailable()) {
+                        if (!capabilityManager.isAnyTransferMethodAvailable()) {
                             vm.setState(ShowQrCodeState.NO_TRANSFER_METHOD_AVAILABLE)
                         } else if (showQrCode.value != null && presentationStateModel.state.collectAsState().value != PresentationStateModel.State.PROCESSING) {
                             vm.setState(ShowQrCodeState.SHOW_QR_CODE)

--- a/shared/src/commonMain/kotlin/ui/views/iso/ShowQrCodeView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/iso/ShowQrCodeView.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -33,12 +32,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.button_label_retry
-import at.asitplus.valera.resources.error_bluetooth_unavailable
+import at.asitplus.valera.resources.error_bluetooth_and_nfc_unavailable
 import at.asitplus.valera.resources.error_missing_permissions
 import at.asitplus.valera.resources.heading_label_show_qr_code_screen
 import at.asitplus.valera.resources.info_text_qr_code_loading
-import at.asitplus.wallet.app.common.iso.transfer.BluetoothInfo
 import at.asitplus.wallet.app.common.iso.transfer.MdocConstants.MDOC_PREFIX
+import at.asitplus.wallet.app.common.iso.transfer.isAnyTransferMethodAvailable
 import io.github.alexzhirkevich.qrose.options.QrBrush
 import io.github.alexzhirkevich.qrose.options.QrColors
 import io.github.alexzhirkevich.qrose.options.solid
@@ -62,7 +61,6 @@ import ui.views.LoadingViewBody
 fun ShowQrCodeView(vm: ShowQrCodeViewModel) {
     val blePermissionState = rememberBluetoothPermissionState()
     val showQrCode = remember { mutableStateOf<ByteString?>(null) }
-    val isBluetoothEnabled = BluetoothInfo().isBluetoothEnabled()
     val presentationStateModel = remember { vm.presentationStateModel }
     val showQrCodeState by vm.showQrCodeState.collectAsState()
 
@@ -98,8 +96,8 @@ fun ShowQrCodeView(vm: ShowQrCodeViewModel) {
             ) {
                 when (showQrCodeState) {
                     ShowQrCodeState.INIT -> {
-                        if (!isBluetoothEnabled) {
-                            vm.setState(ShowQrCodeState.BLUETOOTH_DISABLED)
+                        if (!isAnyTransferMethodAvailable()) {
+                            vm.setState(ShowQrCodeState.NO_TRANSFER_METHOD_AVAILABLE)
                         } else if (showQrCode.value != null && presentationStateModel.state.collectAsState().value != PresentationStateModel.State.PROCESSING) {
                             vm.setState(ShowQrCodeState.SHOW_QR_CODE)
                         } else if (!blePermissionState.isGranted) {
@@ -109,9 +107,9 @@ fun ShowQrCodeView(vm: ShowQrCodeViewModel) {
                         }
                     }
 
-                    ShowQrCodeState.BLUETOOTH_DISABLED -> {
+                    ShowQrCodeState.NO_TRANSFER_METHOD_AVAILABLE -> {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(stringResource(Res.string.error_bluetooth_unavailable))
+                            Text(stringResource(Res.string.error_bluetooth_and_nfc_unavailable))
                             TextIconButton(
                                 icon = { Icons.Default.Repeat },
                                 text = { Text(stringResource(Res.string.button_label_retry)) },

--- a/shared/src/commonMain/kotlin/ui/views/iso/ShowQrCodeView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/iso/ShowQrCodeView.kt
@@ -63,7 +63,6 @@ fun ShowQrCodeView(vm: ShowQrCodeViewModel) {
     val showQrCode = remember { mutableStateOf<ByteString?>(null) }
     val presentationStateModel = remember { vm.presentationStateModel }
     val showQrCodeState by vm.showQrCodeState.collectAsState()
-    val capabilityManager = CapabilityManager()
 
     Scaffold(
         topBar = {
@@ -97,7 +96,7 @@ fun ShowQrCodeView(vm: ShowQrCodeViewModel) {
             ) {
                 when (showQrCodeState) {
                     ShowQrCodeState.INIT -> {
-                        if (!capabilityManager.isAnyTransferMethodAvailable()) {
+                        if (!CapabilityManager.isAnyTransferMethodAvailable()) {
                             vm.setState(ShowQrCodeState.NO_TRANSFER_METHOD_AVAILABLE)
                         } else if (showQrCode.value != null && presentationStateModel.state.collectAsState().value != PresentationStateModel.State.PROCESSING) {
                             vm.setState(ShowQrCodeState.SHOW_QR_CODE)

--- a/shared/src/commonMain/kotlin/ui/views/iso/verifier/VerifierView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/iso/verifier/VerifierView.kt
@@ -23,9 +23,8 @@ fun VerifierView(
     bottomBar: @Composable () -> Unit
 ) {
     val verifierState by vm.verifierState.collectAsState()
-    val capabilityManager = CapabilityManager()
 
-    if (!capabilityManager.isAnyTransferMethodAvailable()) {
+    if (!CapabilityManager.isAnyTransferMethodAvailable()) {
         vm.handleError(stringResource(Res.string.error_bluetooth_and_nfc_unavailable))
     }
 

--- a/shared/src/commonMain/kotlin/ui/views/iso/verifier/VerifierView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/iso/verifier/VerifierView.kt
@@ -4,15 +4,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import at.asitplus.valera.resources.Res
+import at.asitplus.valera.resources.error_bluetooth_and_nfc_unavailable
 import at.asitplus.valera.resources.info_text_waiting_for_response
-import at.asitplus.wallet.app.common.iso.transfer.BluetoothInfo
+import at.asitplus.wallet.app.common.iso.transfer.isAnyTransferMethodAvailable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 import org.multipaz.compose.permissions.rememberBluetoothPermissionState
 import ui.viewmodels.iso.VerifierState
 import ui.viewmodels.iso.VerifierViewModel
-import org.jetbrains.compose.resources.stringResource
 import ui.views.LoadingView
 
 @Composable
@@ -23,10 +24,8 @@ fun VerifierView(
 ) {
     val verifierState by vm.verifierState.collectAsState()
 
-    val isBluetoothEnabled = BluetoothInfo().isBluetoothEnabled()
-    if (!isBluetoothEnabled) {
-        // TODO if bluetooth is not available, NFC data transfer should still work
-        //vm.handleError(stringResource(Res.string.error_bluetooth_unavailable))
+    if (!isAnyTransferMethodAvailable()) {
+        vm.handleError(stringResource(Res.string.error_bluetooth_and_nfc_unavailable))
     }
 
     val blePermissionState = rememberBluetoothPermissionState()

--- a/shared/src/commonMain/kotlin/ui/views/iso/verifier/VerifierView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/iso/verifier/VerifierView.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.getValue
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.error_bluetooth_and_nfc_unavailable
 import at.asitplus.valera.resources.info_text_waiting_for_response
-import at.asitplus.wallet.app.common.iso.transfer.isAnyTransferMethodAvailable
+import at.asitplus.wallet.app.common.iso.transfer.CapabilityManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -23,8 +23,9 @@ fun VerifierView(
     bottomBar: @Composable () -> Unit
 ) {
     val verifierState by vm.verifierState.collectAsState()
+    val capabilityManager = CapabilityManager()
 
-    if (!isAnyTransferMethodAvailable()) {
+    if (!capabilityManager.isAnyTransferMethodAvailable()) {
         vm.handleError(stringResource(Res.string.error_bluetooth_and_nfc_unavailable))
     }
 

--- a/shared/src/iosMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/NfcInfo.ios.kt
+++ b/shared/src/iosMain/kotlin/at/asitplus/wallet/app/common/iso/transfer/NfcInfo.ios.kt
@@ -1,0 +1,12 @@
+package at.asitplus.wallet.app.common.iso.transfer
+
+import androidx.compose.runtime.Composable
+
+actual class NfcInfo {
+    @Composable
+    actual fun isNfcEnabled(): Boolean {
+        // TODO add check if nfc is enabled (if that's even possible on iOS)
+        // for now return true so that NFC can be used if it's enabled
+        return true
+    }
+}


### PR DESCRIPTION
- Add `NfcInfo` equivalents to bluetooth capability check
- Add `CapabilityManager` for handling capability checking requests

_**Note**: This is just a fix for the current state, that just returns if any transfer capability is available. An extended version will include e.g. a check if the device has a capability which is set in the configs._