### PR TITLE
Use uuid to reference throwables

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ErrorService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ErrorService.kt
@@ -5,15 +5,29 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class ErrorService() {
     val error = MutableSharedFlow<ErrorFlowData>(replay = 1)
     private val scope = CoroutineScope(Dispatchers.Default)
 
+    private val map = mutableMapOf<String, Throwable>()
+
+    fun get(throwableId: String): Throwable? = map.remove(throwableId)
+
+    @OptIn(ExperimentalUuidApi::class, ExperimentalUuidApi::class)
+    fun put(throwable: Throwable): String {
+        val id = Uuid.random().toString()
+        map[id] = throwable
+        return id
+    }
+
     fun emit(e: Throwable) = scope.launch {
-        error.emit(ErrorFlowData(e))
+        val id = put(e)
+        error.emit(ErrorFlowData(id))
         Napier.e("Error", e)
     }
 }
 
-data class ErrorFlowData(val throwable: Throwable)
+data class ErrorFlowData(val throwableId: String)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
@@ -36,6 +36,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import at.asitplus.wallet.lib.data.dif.ConstraintFieldsEvaluationException
 import at.asitplus.wallet.lib.data.dif.PresentationExchangeInputEvaluator
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.oidvci.toFormat
@@ -354,4 +355,9 @@ private fun JsonObjectBuilder.addSdJwtDummyMetadata() {
     put("exp", 0)
     put("cnf", buildJsonObject { })
     put("status", buildJsonObject { })
+}
+
+fun Throwable.enrichMessage() = when (this) {
+    is ConstraintFieldsEvaluationException -> "$message ${constraintFieldExceptions.keys}"
+    else -> message ?: toString()
 }

--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -651,10 +651,11 @@ private fun WalletNavHost(
         }
 
         composable<ErrorRoute> { backStackEntry ->
-            val throwableId = backStackEntry.toRoute<ErrorRoute>().throwableId
-            val throwable = remember { walletMain.errorService.get(throwableId) }
-
-            throwable?.let { throwable ->
+            catchingUnwrapped {
+                val throwableId = backStackEntry.toRoute<ErrorRoute>().throwableId
+                remember { walletMain.errorService.get(throwableId) }
+                    ?: throw Throwable("No throwable with id $throwableId")
+            }.onSuccess{ throwable ->
                 ErrorView(remember {
                     ErrorViewModel(
                         resetStack = { popBackStack(HomeScreenRoute) },
@@ -671,6 +672,9 @@ private fun WalletNavHost(
                         onClickSettings = { navigate(SettingsRoute) }
                     )
                 })
+            }.onFailure {
+                popBackStack(HomeScreenRoute)
+                walletMain.errorService.emit(it)
             }
         }
 

--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -31,8 +31,6 @@ import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.CredentialOffer
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.valera.resources.Res
-import at.asitplus.valera.resources.error_feature_not_yet_available
-import at.asitplus.valera.resources.snackbar_clear_log_successfully
 import at.asitplus.valera.resources.snackbar_reset_app_successfully
 import at.asitplus.wallet.app.common.ErrorService
 import at.asitplus.wallet.app.common.KeystoreService
@@ -40,7 +38,6 @@ import at.asitplus.wallet.app.common.SnackbarService
 import at.asitplus.wallet.app.common.WalletMain
 import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.app.common.domain.platform.UrlOpener
-import at.asitplus.wallet.lib.data.dif.ConstraintFieldsEvaluationException
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.openid.AuthorizationResponsePreparationState
 import io.github.aakira.napier.Napier
@@ -93,7 +90,6 @@ import ui.viewmodels.LogViewModel
 import ui.viewmodels.QrCodeScannerMode
 import ui.viewmodels.QrCodeScannerViewModel
 import ui.viewmodels.SigningQtspSelectionViewModel
-import ui.viewmodels.authentication.AuthenticationSuccessViewModel
 import ui.viewmodels.authentication.AuthenticationViewModel
 import ui.viewmodels.authentication.DefaultAuthenticationViewModel
 import ui.viewmodels.authentication.NewDCAPIAuthenticationViewModel
@@ -236,21 +232,13 @@ fun WalletNavigation(
                 if (ready == true) {
                     emit(error)
                 }
-            }.collect { (throwable) ->
+            }.collect { (throwableId) ->
                 navigate(
-                    ErrorRoute(
-                        throwable.enrichMessage(),
-                        throwable.cause?.message ?: throwable.cause?.toString()
-                    )
+                    ErrorRoute(throwableId)
                 )
             }
         }
     }
-}
-
-private fun Throwable.enrichMessage() = when (this) {
-    is ConstraintFieldsEvaluationException -> "$message ${constraintFieldExceptions.keys}"
-    else -> message ?: toString()
 }
 
 @Composable
@@ -663,23 +651,27 @@ private fun WalletNavHost(
         }
 
         composable<ErrorRoute> { backStackEntry ->
-            ErrorView(remember {
-                ErrorViewModel(
-                    resetStack = { popBackStack(HomeScreenRoute) },
-                    resetApp = {
-                        walletMain.scope.launch {
-                            walletMain.resetApp()
-                            val resetMessage = getString(Res.string.snackbar_reset_app_successfully)
-                            walletMain.snackbarService.showSnackbar(resetMessage)
-                            popBackStack(HomeScreenRoute)
-                        }
-                    },
-                    message = backStackEntry.toRoute<ErrorRoute>().message,
-                    cause = backStackEntry.toRoute<ErrorRoute>().cause,
-                    onClickLogo = onClickLogo,
-                    onClickSettings = { navigate(SettingsRoute) }
-                )
-            })
+            val throwableId = backStackEntry.toRoute<ErrorRoute>().throwableId
+            val throwable = remember { walletMain.errorService.get(throwableId) }
+
+            throwable?.let { throwable ->
+                ErrorView(remember {
+                    ErrorViewModel(
+                        resetStack = { popBackStack(HomeScreenRoute) },
+                        resetApp = {
+                            walletMain.scope.launch {
+                                walletMain.resetApp()
+                                val resetMessage = getString(Res.string.snackbar_reset_app_successfully)
+                                walletMain.snackbarService.showSnackbar(resetMessage)
+                                popBackStack(HomeScreenRoute)
+                            }
+                        },
+                        throwable = throwable,
+                        onClickLogo = onClickLogo,
+                        onClickSettings = { navigate(SettingsRoute) }
+                    )
+                })
+            }
         }
 
         composable<LoadingRoute> { backStackEntry ->

--- a/shared/src/commonMain/kotlin/ui/navigation/routes/WalletRoutes.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/routes/WalletRoutes.kt
@@ -30,7 +30,7 @@ object LogRoute : Route()
 data class SigningQtspSelectionRoute(val signatureRequestParametersSerialized: String) : Route()
 
 @Serializable
-data class ErrorRoute(val message: String?, val cause: String?) : Route()
+data class ErrorRoute(val throwableId: String) : Route()
 
 @Serializable
 object LoadingRoute : Route()

--- a/shared/src/commonMain/kotlin/ui/viewmodels/ErrorViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/ErrorViewModel.kt
@@ -5,6 +5,7 @@ import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.info_text_error_action_reset_app
 import at.asitplus.valera.resources.info_text_error_action_start_screen
 import at.asitplus.valera.resources.info_text_error_cause_reset_app
+import at.asitplus.wallet.app.common.enrichMessage
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
@@ -12,14 +13,16 @@ import org.jetbrains.compose.resources.getString
 class ErrorViewModel(
     val resetStack: () -> Unit,
     val resetApp: () -> Unit,
-    val message: String?,
-    val cause: String?,
+    val throwable: Throwable,
     val onClickLogo: () -> Unit,
     val onClickSettings: () -> Unit
 ){
     var onClickButton: () -> Unit
     var actionDescription: StringResource
     var textCause: String?
+
+    val message = throwable.enrichMessage()
+    val cause = throwable.cause?.toString()
 
     init {
         when(message) {


### PR DESCRIPTION
The current implementation is not suitable to do proper error handling for a wide range of errors.
The navigation operates on serializable objects so we cannot pass them directly.

One simple solution is to use uuids to reference throwables through the ErrorService.

This should enable proper handling in further PRs

https://github.com/a-sit-plus/valera/issues/325