### PR TITLE
Reset appReady

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
@@ -82,6 +82,7 @@ class WalletMain(
         KeystoreService.clearKeyMaterial()
 
         settingsRepository.reset()
+        appReady.value = false
         sessionService.newScope()
     }
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/di/AppModule.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/di/AppModule.kt
@@ -16,8 +16,9 @@ import ui.navigation.IntentService
 fun appModule(appDependencyProvider: WalletDependencyProvider) = module {
     scope(named(SESSION_NAME)) {
         scopedOf(::WalletMain)
+        scopedOf(::ErrorService)
+
     }
-    singleOf(::ErrorService)
     singleOf(::IntentService)
     singleOf(::SessionService)
     includes(dataModule())

--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -126,12 +126,11 @@ fun WalletNavigation(
                 popBackStack(HomeScreenRoute)
                 errorService.emit(e)
             },
-            walletMain,
             koinScope = koinScope
         )
     }
 
-    LaunchedEffect(null) {
+    LaunchedEffect(koinScope) {
         this.launch {
             Globals.appLink.combineTransform(walletMain.appReady) { link, ready ->
                 if (ready == true && link != null) {
@@ -179,10 +178,11 @@ private fun WalletNavHost(
     popBackStack: (Route) -> Unit,
     onClickLogo: () -> Unit,
     onError: (Throwable) -> Unit,
-    walletMain: WalletMain,
+    koinScope: Scope,
+    walletMain: WalletMain = koinInject(scope = koinScope),
     intentService: IntentService = koinInject(),
     settingsRepository: SettingsRepository = koinInject(),
-    koinScope: Scope,
+
 ) {
     val currentHost by settingsRepository.host.collectAsState("")
     NavHost(
@@ -231,7 +231,7 @@ private fun WalletNavHost(
                 },
                 koinScope = koinScope
             )
-            LaunchedEffect(null) {
+            LaunchedEffect(koinScope) {
                 walletMain.scope.launch {
                     walletMain.appReady.emit(true)
                 }


### PR DESCRIPTION
Also reset appReady state, otherwise we show intents and errors as early as the onboarding view 