### PR TITLE
Make app installable with different suffix

### DIFF
--- a/androidApp/src/androidMain/AndroidManifest.xml
+++ b/androidApp/src/androidMain/AndroidManifest.xml
@@ -155,7 +155,7 @@
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="at.asitplus.wallet.app.android.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/shared/src/androidMain/kotlin/main.android.kt
+++ b/shared/src/androidMain/kotlin/main.android.kt
@@ -154,7 +154,7 @@ public class AndroidPlatformAdapter(
         val file = File(folder, "log.txt")
         val fileUri = FileProvider.getUriForFile(
             context,
-            "at.asitplus.wallet.app.android.fileprovider",
+            "${context.packageName}.fileprovider",
             file
         )
 


### PR DESCRIPTION
Allows installing the app multiple times with different application id suffixes