### PR TITLE
Update DEVELOPMENT.md with instructions for generating and configurig a keystore for Android app signing

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,25 @@ Development happens in branch `development`. The `main` branch always tracks the
 
 ## Local deployments
 
-To sign the Android App with the correct signer certificate (used for Key Attestation checks on the backend), add the property `android.cert.password` with the correct password to your `local.properties`. For CI deployments, see below.
+Running of the Android App requires a signer certificate to be configured. To do this you will need to generate a keystore file and add the correct keystore password to your `local.properties` file.
+
+Navigate in a temporary directory and run the following commands to generate a keystore file:
+
+```bash
+# Create the Self-Signed Certificate
+openssl req -x509 -newkey rsa:4096 -keyout private.key -out certificate.crt -days 365 -nodes
+# Convert to .p12 Format. You will be asked for a password here, remember it!
+openssl pkcs12 -export -out keystore.p12 -inkey private.key -in certificate.crt -name "key0"
+# Move to the android app directory
+mv keystore.p12 <path-to-repo>/androidApp/keystore.p12
+```
+
+Add the password property (`android.cert.password`) to the `local.properties` file in the root of the project:
+
+```txt
+sdk.dir=<path-to-android-sdk>
+android.cert.password=<your-keystore-password>
+```
 
 ## Deployments
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,10 @@ Development happens in branch `development`. The `main` branch always tracks the
 
 ## Local deployments
 
-Running of the Android App requires a signer certificate to be configured. To do this you will need to generate a keystore file and add the correct keystore password to your `local.properties` file.
+Building of the Android App locally requires a signer certificate to be configured. To do this you will need to generate a keystore file and add the keystore's password to your `local.properties` file.
+
+> [!NOTE]
+> The following instructions are for fine for locally building debug APKs. Inside a CI pipeline, it is highly recommended to use CI secrets that are propagated to environment veriables!
 
 Navigate in a temporary directory and run the following commands to generate a keystore file:
 


### PR DESCRIPTION
This PR adds instructions for generating and configuring a keystore for Android app signing.

Maybe simpler approach would be to make the existing keystore password public and add it as default to the build files.