### PR TITLE
Handle empty presentation matches without crashing

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
@@ -60,6 +60,9 @@ fun InputDescriptor.extractConsentData(): Triple<CredentialRepresentation, Const
         SD_JWT -> vctConstraint()?.filter?.referenceValues()
         ISO_MDOC -> listOf(this.id)
     } ?: throw Throwable("Missing Pattern")
+    check(credentialIdentifiers.isNotEmpty()) {
+        "Presentation definition input descriptor '$id' does not declare any credential identifier"
+    }
 
     // TODO: How to properly handle the case with multiple applicable schemes?
     val scheme = AttributeIndex.schemeSet.firstOrNull {

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/PresentationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/PresentationService.kt
@@ -107,7 +107,8 @@ class PresentationService(
         val presentation =
             presentationResult.getOrThrow() as PresentationResponseParameters.PresentationExchangeParameters
 
-        val deviceResponse = when (val firstResult = presentation.presentationResults[0]) {
+        val deviceResponse = when (val firstResult = presentation.presentationResults.firstOrNull()
+            ?: throw PresentationException(IllegalStateException("Presentation did not return any device response"))) {
             is CreatePresentationResult.DeviceResponse -> firstResult.deviceResponse
             else -> throw PresentationException(IllegalStateException("Must be a device response"))
         }
@@ -165,7 +166,8 @@ class PresentationService(
         val presentation =
             presentationResult.getOrThrow() as PresentationResponseParameters.PresentationExchangeParameters
 
-        val deviceResponse = when (val firstResult = presentation.presentationResults[0]) {
+        val deviceResponse = when (val firstResult = presentation.presentationResults.firstOrNull()
+            ?: throw PresentationException(IllegalStateException("Presentation did not return any device response"))) {
             is CreatePresentationResult.DeviceResponse -> coseCompliantSerializer.encodeToByteArray(
                 firstResult.deviceResponse
             )

--- a/shared/src/commonMain/kotlin/ui/presentation/CredentialSelectionProvider.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/CredentialSelectionProvider.kt
@@ -2,6 +2,7 @@ package ui.presentation
 
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.openid.CredentialMatchingResult
+import at.asitplus.wallet.lib.openid.PresentationExchangeMatchingResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,7 +21,11 @@ fun <Credential : Any> CredentialMatchingResult<Credential>.toCredentialSelectio
     scope: CoroutineScope,
     checkCredentialFreshness: suspend (Credential) -> CredentialFreshnessSummary,
 ) = CredentialSelectionProvider(
-    queryMatchingResult = this,
+    queryMatchingResult = this.also {
+        if (it is PresentationExchangeMatchingResult) {
+            validatePresentationExchangeInputDescriptorMatches(it.matchingResult.inputDescriptorMatches)
+        }
+    },
     credentialFreshnessProviders = this.matchingResult.credentials.map {
         flow {
             emit(CredentialFreshnessValidationStateUiModel.Loading)
@@ -36,3 +41,16 @@ fun <Credential : Any> CredentialMatchingResult<Credential>.toCredentialSelectio
         )
     }
 )
+
+internal fun <Credential : Any, Match : Any> validatePresentationExchangeInputDescriptorMatches(
+    inputDescriptorMatches: Map<String, Map<Credential, Match>>,
+) {
+    val missingDescriptorIds = inputDescriptorMatches
+        .filterValues { it.isEmpty() }
+        .keys
+    check(missingDescriptorIds.isEmpty()) {
+        "Presentation definition input descriptor(s) ${
+            missingDescriptorIds.joinToString(", ")
+        } did not match any stored credential"
+    }
+}

--- a/shared/src/commonMain/kotlin/ui/viewmodels/LoadCredentialViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/LoadCredentialViewModel.kt
@@ -20,6 +20,11 @@ class LoadCredentialViewModel(
     val onClickLogo: () -> Unit,
     val onClickSettings: () -> Unit,
 ) {
+    init {
+        check(credentialIdentifiers.isNotEmpty()) {
+            "Issuer '$hostString' did not provide any credential configuration that can be loaded"
+        }
+    }
 
     companion object {
         suspend fun init(

--- a/shared/src/commonMain/kotlin/ui/viewmodels/authentication/AuthenticationSelectionPresentationExchangeViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/authentication/AuthenticationSelectionPresentationExchangeViewModel.kt
@@ -39,7 +39,10 @@ class AuthenticationSelectionPresentationExchangeViewModel(
         requests.forEach {
             attributeSelection[it.key] = mutableStateMapOf()
             val matchingCredentials = it.value
-            val defaultCredential = matchingCredentials.keys.first()
+            val defaultCredential = matchingCredentials.keys.firstOrNull()
+                ?: throw IllegalStateException(
+                    "Presentation definition input descriptor '${it.key}' did not match any stored credential"
+                )
             credentialSelection[it.key] = mutableStateOf(defaultCredential)
         }
     }

--- a/shared/src/commonTest/kotlin/ui/presentation/CredentialSelectionProviderTest.kt
+++ b/shared/src/commonTest/kotlin/ui/presentation/CredentialSelectionProviderTest.kt
@@ -1,0 +1,33 @@
+package ui.presentation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CredentialSelectionProviderTest {
+    @Test
+    fun rejectsPresentationExchangeDescriptorsWithoutMatches() {
+        val error = assertFailsWith<IllegalStateException> {
+            validatePresentationExchangeInputDescriptorMatches(
+                mapOf(
+                    "matched" to mapOf("credential" to Unit),
+                    "missing" to emptyMap(),
+                )
+            )
+        }
+
+        assertEquals(
+            "Presentation definition input descriptor(s) missing did not match any stored credential",
+            error.message,
+        )
+    }
+
+    @Test
+    fun acceptsPresentationExchangeDescriptorsWithMatches() {
+        validatePresentationExchangeInputDescriptorMatches(
+            mapOf(
+                "matched" to mapOf("credential" to Unit),
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- reject Presentation Exchange descriptors that have no matching stored credential before the selection UI is built
- guard related selection and presentation-result code paths that assumed non-empty collections
- add a regression test for the empty-match Presentation Exchange case

## Verification
- ./gradlew :shared:testAndroidHostTest --tests ui.presentation.CredentialSelectionProviderTest

Fixes #436