### PR TITLE
Handle empty presentation matches without crashing

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
@@ -60,6 +60,9 @@ fun InputDescriptor.extractConsentData(): Triple<CredentialRepresentation, Const
         SD_JWT -> vctConstraint()?.filter?.referenceValues()
         ISO_MDOC -> listOf(this.id)
     } ?: throw Throwable("Missing Pattern")
+    check(credentialIdentifiers.isNotEmpty()) {
+        "Presentation definition input descriptor '$id' does not declare any credential identifier"
+    }
 
     // TODO: How to properly handle the case with multiple applicable schemes?
     val scheme = AttributeIndex.schemeSet.firstOrNull {

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/PresentationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/PresentationService.kt
@@ -107,7 +107,8 @@ class PresentationService(
         val presentation =
             presentationResult.getOrThrow() as PresentationResponseParameters.PresentationExchangeParameters
 
-        val deviceResponse = when (val firstResult = presentation.presentationResults[0]) {
+        val deviceResponse = when (val firstResult = presentation.presentationResults.firstOrNull()
+            ?: throw PresentationException(IllegalStateException("Presentation did not return any device response"))) {
             is CreatePresentationResult.DeviceResponse -> firstResult.deviceResponse
             else -> throw PresentationException(IllegalStateException("Must be a device response"))
         }
@@ -165,7 +166,8 @@ class PresentationService(
         val presentation =
             presentationResult.getOrThrow() as PresentationResponseParameters.PresentationExchangeParameters
 
-        val deviceResponse = when (val firstResult = presentation.presentationResults[0]) {
+        val deviceResponse = when (val firstResult = presentation.presentationResults.firstOrNull()
+            ?: throw PresentationException(IllegalStateException("Presentation did not return any device response"))) {
             is CreatePresentationResult.DeviceResponse -> coseCompliantSerializer.encodeToByteArray(
                 firstResult.deviceResponse
             )

--- a/shared/src/commonMain/kotlin/data/credentials/EuPidCredentialAttributeCategorization.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/EuPidCredentialAttributeCategorization.kt
@@ -2,7 +2,6 @@ package data.credentials
 
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.wallet.eupid.EuPidScheme
-import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
 import data.PersonalDataCategory
 
 @Suppress("DEPRECATION")
@@ -80,54 +79,3 @@ object EuPidCredentialAttributeCategorization : CredentialAttributeCategorizatio
     },
 )
 
-object EuPidSdJwtCredentialAttributeCategorization : CredentialAttributeCategorization.Template(
-    mapOf(
-        PersonalDataCategory.IdentityData to with(EuPidSdJwtScheme.SdJwtAttributes) {
-            listOf(
-                GIVEN_NAME,
-                FAMILY_NAME,
-                BIRTH_DATE,
-                PORTRAIT,
-                NATIONALITIES,
-                SEX,
-            ).map { NormalizedJsonPath() + it to null }
-        },
-
-        PersonalDataCategory.BirthData to with(EuPidSdJwtScheme.SdJwtAttributes) {
-            listOf(
-                GIVEN_NAME_BIRTH,
-                FAMILY_NAME_BIRTH,
-                PLACE_OF_BIRTH_LOCALITY,
-                PLACE_OF_BIRTH_COUNTRY,
-                PLACE_OF_BIRTH_REGION,
-            ).map { NormalizedJsonPath() + it to null }
-        },
-
-        PersonalDataCategory.ResidenceData to with(EuPidSdJwtScheme.SdJwtAttributes) {
-            listOf(
-                ADDRESS_STREET,
-                ADDRESS_HOUSE_NUMBER,
-                ADDRESS_POSTAL_CODE,
-                ADDRESS_LOCALITY,
-                ADDRESS_COUNTRY,
-                ADDRESS_REGION,
-                ADDRESS_FORMATTED,
-            ).map { NormalizedJsonPath() + it to null }
-        },
-
-        PersonalDataCategory.Metadata to with(EuPidSdJwtScheme.SdJwtAttributes) {
-            listOf(
-                DOCUMENT_NUMBER,
-                ISSUANCE_DATE,
-                EXPIRY_DATE,
-                ISSUING_COUNTRY,
-                ISSUING_AUTHORITY,
-                ISSUING_JURISDICTION,
-                PERSONAL_ADMINISTRATIVE_NUMBER,
-            ).map { NormalizedJsonPath() + it to null }
-        },
-    ),
-    allAttributes = EuPidSdJwtScheme.claimNames.map {
-        NormalizedJsonPath() + it
-    },
-)

--- a/shared/src/commonMain/kotlin/data/credentials/EuPidSdJwtCredentialAttributeCategorization.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/EuPidSdJwtCredentialAttributeCategorization.kt
@@ -1,0 +1,2 @@
+package data.credentials 
+

--- a/shared/src/commonMain/kotlin/data/credentials/EuPidSdJwtCredentialAttributeCategorization.kt
+++ b/shared/src/commonMain/kotlin/data/credentials/EuPidSdJwtCredentialAttributeCategorization.kt
@@ -1,2 +1,76 @@
-package data.credentials 
+package data.credentials
 
+import at.asitplus.jsonpath.core.NormalizedJsonPath
+import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtScheme
+import data.PersonalDataCategory
+
+object EuPidSdJwtCredentialAttributeCategorization : CredentialAttributeCategorization.Template(
+    mapOf(
+        PersonalDataCategory.IdentityData to with(EuPidSdJwtScheme.SdJwtAttributes) {
+            listOf(
+                GIVEN_NAME,
+                FAMILY_NAME,
+                BIRTH_DATE,
+                PORTRAIT,
+                NATIONALITIES,
+                SEX,
+            ).map { NormalizedJsonPath() + it to null }
+        },
+
+        PersonalDataCategory.BirthData to with(EuPidSdJwtScheme.SdJwtAttributes) {
+            listOf(
+                GIVEN_NAME_BIRTH,
+                FAMILY_NAME_BIRTH,
+                PLACE_OF_BIRTH_LOCALITY,
+                PLACE_OF_BIRTH_COUNTRY,
+                PLACE_OF_BIRTH_REGION,
+            ).map { NormalizedJsonPath() + it to null }
+        },
+
+        PersonalDataCategory.ResidenceData to with(EuPidSdJwtScheme.SdJwtAttributes) {
+            listOf(
+                ADDRESS_STREET,
+                ADDRESS_HOUSE_NUMBER,
+                ADDRESS_POSTAL_CODE,
+                ADDRESS_LOCALITY,
+                ADDRESS_COUNTRY,
+                ADDRESS_REGION,
+                ADDRESS_FORMATTED,
+            ).map { NormalizedJsonPath() + it to null }
+        },
+
+        PersonalDataCategory.Metadata to with(EuPidSdJwtScheme.SdJwtAttributes) {
+            listOf(
+                DOCUMENT_NUMBER,
+                ISSUANCE_DATE,
+                EXPIRY_DATE,
+                ISSUING_COUNTRY,
+                ISSUING_AUTHORITY,
+                ISSUING_JURISDICTION,
+                PERSONAL_ADMINISTRATIVE_NUMBER,
+            ).map { NormalizedJsonPath() + it to null }
+        },
+
+
+        PersonalDataCategory.AgeData to with(EuPidSdJwtScheme.SdJwtAttributes) {
+            listOf(
+                AGE_EQUAL_OR_OVER_12,
+                AGE_EQUAL_OR_OVER_13,
+                AGE_EQUAL_OR_OVER_14,
+                AGE_EQUAL_OR_OVER_16,
+                AGE_EQUAL_OR_OVER_18,
+                AGE_EQUAL_OR_OVER_21,
+                AGE_EQUAL_OR_OVER_25,
+                AGE_EQUAL_OR_OVER_60,
+                AGE_EQUAL_OR_OVER_62,
+                AGE_EQUAL_OR_OVER_65,
+                AGE_EQUAL_OR_OVER_68,
+                AGE_BIRTH_YEAR,
+                AGE_IN_YEARS,
+            ).map { NormalizedJsonPath() + it to null }
+        },
+    ),
+    allAttributes = EuPidSdJwtScheme.claimNames.map {
+        NormalizedJsonPath() + it
+    },
+)

--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -258,6 +258,7 @@ private fun WalletNavHost(
                 onConfirm = {
                     processedItemIds = processedItemIds + item.storeEntryId
                     walletMain.credentialValidityService.refreshSingleWithStatus(item)
+                    navController.navigate(RefreshCenterRoute) { launchSingleTop = true }
                 },
                 onDismiss = {
                     walletMain.credentialValidityService.removeRefreshRequest(item)

--- a/shared/src/commonMain/kotlin/ui/presentation/CredentialSelectionProvider.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/CredentialSelectionProvider.kt
@@ -2,6 +2,7 @@ package ui.presentation
 
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.openid.CredentialMatchingResult
+import at.asitplus.wallet.lib.openid.PresentationExchangeMatchingResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,7 +21,11 @@ fun <Credential : Any> CredentialMatchingResult<Credential>.toCredentialSelectio
     scope: CoroutineScope,
     checkCredentialFreshness: suspend (Credential) -> CredentialFreshnessSummary,
 ) = CredentialSelectionProvider(
-    queryMatchingResult = this,
+    queryMatchingResult = this.also {
+        if (it is PresentationExchangeMatchingResult) {
+            validatePresentationExchangeInputDescriptorMatches(it.matchingResult.inputDescriptorMatches)
+        }
+    },
     credentialFreshnessProviders = this.matchingResult.credentials.map {
         flow {
             emit(CredentialFreshnessValidationStateUiModel.Loading)
@@ -36,3 +41,16 @@ fun <Credential : Any> CredentialMatchingResult<Credential>.toCredentialSelectio
         )
     }
 )
+
+internal fun <Credential : Any, Match : Any> validatePresentationExchangeInputDescriptorMatches(
+    inputDescriptorMatches: Map<String, Map<Credential, Match>>,
+) {
+    val missingDescriptorIds = inputDescriptorMatches
+        .filterValues { it.isEmpty() }
+        .keys
+    check(missingDescriptorIds.isEmpty()) {
+        "Presentation definition input descriptor(s) ${
+            missingDescriptorIds.joinToString(", ")
+        } did not match any stored credential"
+    }
+}

--- a/shared/src/commonMain/kotlin/ui/presentation/CredentialSelectionProvider.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/CredentialSelectionProvider.kt
@@ -2,7 +2,6 @@ package ui.presentation
 
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.openid.CredentialMatchingResult
-import at.asitplus.wallet.lib.openid.PresentationExchangeMatchingResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -21,11 +20,7 @@ fun <Credential : Any> CredentialMatchingResult<Credential>.toCredentialSelectio
     scope: CoroutineScope,
     checkCredentialFreshness: suspend (Credential) -> CredentialFreshnessSummary,
 ) = CredentialSelectionProvider(
-    queryMatchingResult = this.also {
-        if (it is PresentationExchangeMatchingResult) {
-            validatePresentationExchangeInputDescriptorMatches(it.matchingResult.inputDescriptorMatches)
-        }
-    },
+    queryMatchingResult = this,
     credentialFreshnessProviders = this.matchingResult.credentials.map {
         flow {
             emit(CredentialFreshnessValidationStateUiModel.Loading)
@@ -42,15 +37,6 @@ fun <Credential : Any> CredentialMatchingResult<Credential>.toCredentialSelectio
     }
 )
 
-internal fun <Credential : Any, Match : Any> validatePresentationExchangeInputDescriptorMatches(
+internal fun <Credential : Any, Match : Any> hasMissingPresentationExchangeInputDescriptorMatches(
     inputDescriptorMatches: Map<String, Map<Credential, Match>>,
-) {
-    val missingDescriptorIds = inputDescriptorMatches
-        .filterValues { it.isEmpty() }
-        .keys
-    check(missingDescriptorIds.isEmpty()) {
-        "Presentation definition input descriptor(s) ${
-            missingDescriptorIds.joinToString(", ")
-        } did not match any stored credential"
-    }
-}
+) = inputDescriptorMatches.values.any { it.isEmpty() }

--- a/shared/src/commonMain/kotlin/ui/presentation/DefaultPresentationGraphViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/DefaultPresentationGraphViewModel.kt
@@ -16,6 +16,7 @@ import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.ktor.openid.OpenId4VpWallet
+import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.getString
@@ -119,13 +120,14 @@ class DefaultPresentationGraphViewModel(
     private fun finalizeDcApi(
         authenticationResult: OpenId4VpWallet.AuthenticationForward,
     ): OpenId4VpWallet.AuthenticationSuccess {
-        authenticationResult.authenticationResponseResult.params.let {
-            val serializedResponse = vckJsonSerializer.encodeToString(it)
-            walletMain.presentationService.finalizeOid4vpDCAPIPresentation(serializedResponse)
-        }
+        walletMain.presentationService.finalizeOid4vpDCAPIPresentation(
+            serializeDcApiPresentationResponse(authenticationResult.authenticationResponseResult)
+        )
         return OpenId4VpWallet.AuthenticationSuccess()
     }
 }
 
-
+internal fun serializeDcApiPresentationResponse(
+    authenticationResponseResult: AuthenticationResponseResult.DcApi,
+) = vckJsonSerializer.encodeToString(authenticationResponseResult.params.data)
 

--- a/shared/src/commonMain/kotlin/ui/presentation/PresentationBuilderGraphView.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/PresentationBuilderGraphView.kt
@@ -16,8 +16,10 @@ import at.asitplus.wallet.lib.openid.PresentationExchangeMatchingResult
 import org.jetbrains.compose.resources.stringResource
 import ui.composables.DCQLCredentialQuerySubmissionSelectionOption
 import ui.composables.DelayedComposable
+import ui.viewmodels.authentication.AuthenticationNoCredentialViewModel
 import ui.viewmodels.authentication.CredentialPresentationSubmissions
 import ui.viewmodels.authentication.DCQLCredentialSubmissions
+import ui.views.authentication.AuthenticationNoCredentialView
 import ui.views.LoadingView
 import kotlin.time.Duration.Companion.seconds
 
@@ -32,6 +34,7 @@ fun PresentationBuilderGraphView(
     onClickLogo: () -> Unit,
     onClickSettings: () -> Unit,
     onError: (Throwable) -> Unit,
+    onNavigateUp: () -> Unit,
     onNavigateToPresentationStart: () -> Unit,
     onSubmit: (CredentialPresentationSubmissions<SubjectCredentialStore.StoreEntry>) -> Unit,
 ) {
@@ -125,19 +128,30 @@ fun PresentationBuilderGraphView(
                     )
                 }
 
-                is PresentationExchangeMatchingResult -> PresentationExchangePresentationBuilderGraphView(
-                    authenticateAtRelyingParty = authenticateAtRelyingParty,
-                    serviceProviderLocalizedLocation = serviceProviderLocalizedLocation,
-                    serviceProviderLocalizedName = serviceProviderLocalizedName,
-                    onClickLogo = onClickLogo,
-                    onClickSettings = onClickSettings,
-                    matchingResult = selectionProvider.value.queryMatchingResult,
-                    onError = onError,
-                    onNavigateUp = onNavigateToPresentationStart,
-                    onSubmit = onSubmit,
-                )
+                is PresentationExchangeMatchingResult -> if (
+                    hasMissingPresentationExchangeInputDescriptorMatches(
+                        queryMatchingResult.matchingResult.inputDescriptorMatches
+                    )
+                ) {
+                    AuthenticationNoCredentialView(
+                        AuthenticationNoCredentialViewModel(
+                            navigateToHomeScreen = onNavigateUp,
+                        )
+                    )
+                } else {
+                    PresentationExchangePresentationBuilderGraphView(
+                        authenticateAtRelyingParty = authenticateAtRelyingParty,
+                        serviceProviderLocalizedLocation = serviceProviderLocalizedLocation,
+                        serviceProviderLocalizedName = serviceProviderLocalizedName,
+                        onClickLogo = onClickLogo,
+                        onClickSettings = onClickSettings,
+                        matchingResult = selectionProvider.value.queryMatchingResult,
+                        onError = onError,
+                        onNavigateUp = onNavigateToPresentationStart,
+                        onSubmit = onSubmit,
+                    )
+                }
             }
         }
     }
 }
-

--- a/shared/src/commonMain/kotlin/ui/presentation/PresentationGraphView.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/PresentationGraphView.kt
@@ -114,6 +114,7 @@ fun PresentationGraphView(
                 onClickLogo = onClickLogo,
                 onClickSettings = onClickSettings,
                 onError = onError,
+                onNavigateUp = onNavigateUp,
                 onNavigateToPresentationStart = {
                     navController.navigate(PresentationStartRoute) {
                         popUpTo(PresentationStartRoute) {
@@ -148,4 +149,3 @@ fun PresentationGraphView(
         }
     }
 }
-

--- a/shared/src/commonMain/kotlin/ui/viewmodels/LoadCredentialViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/LoadCredentialViewModel.kt
@@ -20,6 +20,11 @@ class LoadCredentialViewModel(
     val onClickLogo: () -> Unit,
     val onClickSettings: () -> Unit,
 ) {
+    init {
+        check(credentialIdentifiers.isNotEmpty()) {
+            "Issuer '$hostString' did not provide any credential configuration that can be loaded"
+        }
+    }
 
     companion object {
         suspend fun init(

--- a/shared/src/commonMain/kotlin/ui/viewmodels/authentication/AuthenticationSelectionPresentationExchangeViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/authentication/AuthenticationSelectionPresentationExchangeViewModel.kt
@@ -39,7 +39,10 @@ class AuthenticationSelectionPresentationExchangeViewModel(
         requests.forEach {
             attributeSelection[it.key] = mutableStateMapOf()
             val matchingCredentials = it.value
-            val defaultCredential = matchingCredentials.keys.first()
+            val defaultCredential = matchingCredentials.keys.firstOrNull()
+                ?: throw IllegalStateException(
+                    "Presentation definition input descriptor '${it.key}' did not match any stored credential"
+                )
             credentialSelection[it.key] = mutableStateOf(defaultCredential)
         }
     }

--- a/shared/src/commonTest/kotlin/ui/presentation/CredentialSelectionProviderTest.kt
+++ b/shared/src/commonTest/kotlin/ui/presentation/CredentialSelectionProviderTest.kt
@@ -1,0 +1,33 @@
+package ui.presentation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CredentialSelectionProviderTest {
+    @Test
+    fun rejectsPresentationExchangeDescriptorsWithoutMatches() {
+        val error = assertFailsWith<IllegalStateException> {
+            validatePresentationExchangeInputDescriptorMatches(
+                mapOf(
+                    "matched" to mapOf("credential" to Unit),
+                    "missing" to emptyMap(),
+                )
+            )
+        }
+
+        assertEquals(
+            "Presentation definition input descriptor(s) missing did not match any stored credential",
+            error.message,
+        )
+    }
+
+    @Test
+    fun acceptsPresentationExchangeDescriptorsWithMatches() {
+        validatePresentationExchangeInputDescriptorMatches(
+            mapOf(
+                "matched" to mapOf("credential" to Unit),
+            )
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/ui/presentation/CredentialSelectionProviderTest.kt
+++ b/shared/src/commonTest/kotlin/ui/presentation/CredentialSelectionProviderTest.kt
@@ -1,33 +1,77 @@
 package ui.presentation
 
+import at.asitplus.dcapi.OpenId4VpResponseSigned
+import at.asitplus.dcapi.OpenId4VpResponseUnsigned
+import at.asitplus.openid.AuthenticationResponseParameters
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
+import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class CredentialSelectionProviderTest {
     @Test
-    fun rejectsPresentationExchangeDescriptorsWithoutMatches() {
-        val error = assertFailsWith<IllegalStateException> {
-            validatePresentationExchangeInputDescriptorMatches(
+    fun detectsPresentationExchangeDescriptorsWithoutMatches() {
+        assertTrue(
+            hasMissingPresentationExchangeInputDescriptorMatches(
                 mapOf(
                     "matched" to mapOf("credential" to Unit),
                     "missing" to emptyMap(),
                 )
             )
-        }
-
-        assertEquals(
-            "Presentation definition input descriptor(s) missing did not match any stored credential",
-            error.message,
         )
     }
 
     @Test
     fun acceptsPresentationExchangeDescriptorsWithMatches() {
-        validatePresentationExchangeInputDescriptorMatches(
-            mapOf(
-                "matched" to mapOf("credential" to Unit),
+        assertFalse(
+            hasMissingPresentationExchangeInputDescriptorMatches(
+                mapOf(
+                    "matched" to mapOf("credential" to Unit),
+                )
             )
         )
+    }
+
+    @Test
+    fun serializesUnsignedDcApiResponsesWithoutTheOuterWrapper() {
+        val serializedResponse = serializeDcApiPresentationResponse(
+            AuthenticationResponseResult.DcApi(
+                OpenId4VpResponseUnsigned(
+                    data = AuthenticationResponseParameters(
+                        state = "state",
+                        vpToken = JsonPrimitive("vp-token"),
+                    ),
+                    origin = "https://wallet.example",
+                )
+            )
+        )
+
+        val parsedResponse = vckJsonSerializer.decodeFromString<AuthenticationResponseParameters>(serializedResponse)
+        assertEquals("state", parsedResponse.state)
+        assertEquals(JsonPrimitive("vp-token"), parsedResponse.vpToken)
+        assertFalse(serializedResponse.contains("\"protocol\""))
+        assertFalse(serializedResponse.contains("\"data\""))
+    }
+
+    @Test
+    fun serializesEncryptedDcApiResponsesAsAuthenticationResponseParameters() {
+        val serializedResponse = serializeDcApiPresentationResponse(
+            AuthenticationResponseResult.DcApi(
+                OpenId4VpResponseSigned(
+                    data = AuthenticationResponseParameters(
+                        response = "header.payload.signature.encrypted.tag",
+                    ),
+                    origin = "https://wallet.example",
+                )
+            )
+        )
+
+        val parsedResponse = vckJsonSerializer.decodeFromString<AuthenticationResponseParameters>(serializedResponse)
+        assertEquals("header.payload.signature.encrypted.tag", parsedResponse.response)
+        assertFalse(serializedResponse.contains("\"protocol\""))
+        assertFalse(serializedResponse.contains("\"data\""))
     }
 }


### PR DESCRIPTION
## Summary
- reject Presentation Exchange descriptors that have no matching stored credential before the selection UI is built
- guard related selection and presentation-result code paths that assumed non-empty collections
- add a regression test for the empty-match Presentation Exchange case

## Verification
- ./gradlew :shared:testAndroidHostTest --tests ui.presentation.CredentialSelectionProviderTest

Fixes #436

iOS Build is fixed in https://github.com/a-sit-plus/valera/pull/434