### PR TITLE
Update key attestation for EUDI Wallet TS3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release 5.7.7 (unreleased)
  * Update to VC-K 5.13.0
  * Credentials: Show credential titles in refresh prompts and allow suppressing a prompt for a single credential
+ * Issuing: Update key attestation to VC-K 6.0 / TS3 WUA 1.5 APIs
 
 # Release 5.7.6
  * Update to VC-K 5.12.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,8 @@ qrose = "1.0.1"
 core-splashscreen = "1.0.1"
 
 authcheckkit = "1.0.0-alpha01"
+warden-supreme = "1.0.0-RC3"
+
 
 # Test if DC API is still working after upgrading the following libraries
 androidx-credentials = "1.6.0-beta03"
@@ -83,6 +85,8 @@ semver = { module = "net.swiftzer.semver:semver", version.ref = "semver" }
 core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "core-splashscreen" }
 back-handler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-plugin" }
 authcheckkit = { module = "at.asitplus.authcheckkit:core", version.ref = "authcheckkit"}
+warden-supreme = { module = "at.asitplus.warden:supreme-client", version.ref = "warden-supreme" }
+
 
 
 vck = {group= "at.asitplus.wallet", name="vck", version.ref = "vck"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ qrose = "1.0.1"
 core-splashscreen = "1.0.1"
 
 authcheckkit = "1.0.0-alpha01"
-warden-supreme = "1.0.0-RC3"
+warden-supreme = "1.0.0-RC5"
 
 
 # Test if DC API is still working after upgrading the following libraries

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ qrose = "1.0.1"
 core-splashscreen = "1.0.1"
 
 authcheckkit = "1.0.0-alpha01"
-warden-supreme = "1.0.0-RC5"
+warden-supreme = "1.0.0-RC11"
 
 
 # Test if DC API is still working after upgrading the following libraries

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-vck="5.13.0"
+vck="6.0.0-SNAPSHOT"
 
 agp = "8.12.3"
 kotlin = "2.3.0"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -108,6 +108,7 @@ kotlin {
             implementation(libs.koin.compose.viewmodel)
             implementation(libs.koin.compose.viewmodel.navigation)
             implementation(libs.authcheckkit)
+            api(libs.warden.supreme)
         }
 
         commonTest.dependencies {

--- a/shared/src/androidMain/kotlin/main.android.kt
+++ b/shared/src/androidMain/kotlin/main.android.kt
@@ -22,28 +22,19 @@ import androidx.credentials.registry.provider.RegistryManager
 import androidx.credentials.registry.provider.selectedEntryId
 import at.asitplus.KmmResult
 import at.asitplus.catching
-import at.asitplus.dcapi.DCAPIResponse
-import at.asitplus.dcapi.DigitalCredentialInterface
-import at.asitplus.dcapi.EncryptedResponse
-import at.asitplus.dcapi.EncryptedResponseData
-import at.asitplus.dcapi.IsoMdocResponse
-import at.asitplus.dcapi.request.DCAPIWalletRequest
+import at.asitplus.dcapi.*
 import at.asitplus.dcapi.request.ExchangeProtocolIdentifier
 import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest
 import at.asitplus.dcapi.request.verifier.DigitalCredentialRequestOptions
 import at.asitplus.iso.EncryptionParameters
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.cosef.CoseKeyParams.EcKeyParams
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.josef.typed
 import at.asitplus.wallet.app.android.dcapi.CustomRegistry
 import at.asitplus.wallet.app.android.dcapi.DCAPIInvocationData
-import at.asitplus.wallet.app.common.BuildContext
-import at.asitplus.wallet.app.common.CapabilitiesService
-import at.asitplus.wallet.app.common.KeystoreService
-import at.asitplus.wallet.app.common.PlatformAdapter
-import at.asitplus.wallet.app.common.RealCapabilitiesService
-import at.asitplus.wallet.app.common.SESSION_NAME
-import at.asitplus.wallet.app.common.WalletDependencyProvider
+import at.asitplus.wallet.app.common.*
 import at.asitplus.wallet.app.common.dcapi.data.export.CredentialRegistry
 import at.asitplus.wallet.app.common.di.appModule
 import data.storage.RealDataStoreService
@@ -240,7 +231,7 @@ public class AndroidPlatformAdapter(
     }
 
     @OptIn(ExperimentalDigitalCredentialApi::class, ExperimentalEncodingApi::class)
-    override fun getCurrentDCAPIData(): KmmResult<DCAPIWalletRequest> = catching {
+    override fun getCurrentDCAPIVerificationData(): KmmResult<RequestParametersFrom.DcApiRequest> = catching {
         (Globals.dcapiInvocationData.value as DCAPIInvocationData?)?.let { (intent, _) ->
             // Adapted from https://github.com/openwallet-foundation-labs/identity-credential/blob/d7a37a5c672ed6fe1d863cbaeb1a998314d19fc5/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt#L74
             val credentialRequest = PendingIntentHandler.retrieveProviderGetCredentialRequest(intent)
@@ -272,32 +263,39 @@ public class AndroidPlatformAdapter(
 
             Napier.d("DC API: Got request ${option.requestJson} for selection $selectionInfo")
 
-            val credentialId = selectionInfo.documentIds[0]
+            val credentialIds = selectionInfo.documentIds
 
             when (digitalCredentialGetRequest) {
                 is DigitalCredentialGetRequest.OpenId4VpSigned -> {
-                    Napier.d("Using OpenID4VP Signed, got request $digitalCredentialGetRequest for credential ID $credentialId")
-                    DCAPIWalletRequest.OpenId4VpSigned(
-                        request = digitalCredentialGetRequest.request,
-                        credentialIds = setOf(credentialId),
+                    Napier.d("Using OpenID4VP Signed, got request $digitalCredentialGetRequest for credential IDs $credentialIds")
+                    RequestParametersFrom.OpenId4VpDcApiSigned(
+                        jwsTyped = digitalCredentialGetRequest.data.request.typed(),
+                        credentialIds = credentialIds,
                         callingPackageName = callingPackageName,
                         callingOrigin = callingOrigin
                     )
                 }
+                is DigitalCredentialGetRequest.OpenId4VpMultiSigned -> {
+                    TODO("OpenID4VP multisigned DC API requests are not supported yet")
+                }
                 is DigitalCredentialGetRequest.OpenId4VpUnsigned -> {
-                    Napier.d("Using OpenID4VP Unsigned, got request $digitalCredentialGetRequest for credential ID $credentialId")
-                    DCAPIWalletRequest.OpenId4VpUnsigned(
-                        request = digitalCredentialGetRequest.request,
-                        credentialIds = setOf(credentialId),
+                    Napier.d("Using OpenID4VP Unsigned, got request $digitalCredentialGetRequest for credential IDs $credentialIds")
+                    RequestParametersFrom.OpenId4VpDcApiUnsigned(
+                        parameters = digitalCredentialGetRequest.data,
+                        jsonString = joseCompliantSerializer.encodeToString(digitalCredentialGetRequest.data),
+                        credentialIds = credentialIds,
                         callingPackageName = callingPackageName,
                         callingOrigin = callingOrigin
                     )
                 }
                 is DigitalCredentialGetRequest.IsoMdoc -> {
-                    Napier.d("Using Iso 18013-7 Annex C, got request $digitalCredentialGetRequest for credential ID $credentialId")
-                    DCAPIWalletRequest.IsoMdoc(
-                        isoMdocRequest = digitalCredentialGetRequest.request,
-                        credentialIds = setOf(credentialId),
+                    Napier.d("Using Iso 18013-7 Annex C, got request $digitalCredentialGetRequest for credential IDs $credentialIds")
+                    RequestParametersFrom.IsoMdocDcApi(
+                        parameters = RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper(
+                            digitalCredentialGetRequest.data
+                        ),
+                        jsonString = joseCompliantSerializer.encodeToString(digitalCredentialGetRequest.data),
+                        credentialIds = credentialIds,
                         callingPackageName = callingPackageName,
                         callingOrigin = callingOrigin
                     )

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -55,6 +55,7 @@
     <string name="button_label_hide_technical_details">Technische Details ausblenden</string>
     <string name="button_label_sign">Signieren</string>
     <string name="button_label_back">Zurück</string>
+    <string name="button_label_attestation_config">Attestierungs-Konfiguration</string>
 
     <string name="attribute_friendly_name_bpk">BPK</string>
     <string name="attribute_friendly_name_firstname">Vorname</string>
@@ -246,6 +247,7 @@
     <string name="text_label_vcType">VcType</string>
     <string name="text_label_docType">DocType</string>
     <string name="text_label_select_no_optional_credential_set_query_option">Nichts senden</string>
+    <string name="text_label_wallet_provider">Wallet-Provider</string>
 
     <string name="heading_label_credential_selection">Welche Daten sollen präsentiert werden?</string>
     <string name="heading_label_authenticate_at_device_title">Anmelden</string>
@@ -276,6 +278,7 @@
     <string name="heading_label_result">Ergebnis</string>
     <string name="heading_label_device_engagement">Verbindungsaufbau</string>
     <string name="heading_label_capabilities">Gerätefunktionen</string>
+    <string name="heading_label_attestation">Attestierung</string>
 
     <string name="biometric_authentication_prompt_for_data_transmission_consent_title">Daten vorzeigen</string>
     <string name="biometric_authentication_prompt_to_load_data_title">Daten laden</string>
@@ -537,4 +540,12 @@
     <string name="success_reissued">Neu ausgestellt</string>
     <string name="error_reissue_failed">Neuausstellung fehlgeschlagen</string>
     <string name="error_refresh_failed">Aktualisierung fehlgeschlagen</string>
+
+    <!-- AttestationSettings -->
+    <string name="text_label_instance_attestation">Instance-Attestation</string>
+    <string name="text_label_unit_attestation">Unit-Attestation</string>
+    <string name="button_label_load_attestation">Attestation laden</string>
+    <string name="text_label_attestation_issued">Gültig von</string>
+    <string name="text_label_attestation_expiration">Gültig bis</string>
+    <string name="text_label_attestation_storage_type">Speichertyp</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -547,5 +547,5 @@
     <string name="button_label_load_attestation">Attestation laden</string>
     <string name="text_label_attestation_issued">Gültig von</string>
     <string name="text_label_attestation_expiration">Gültig bis</string>
-    <string name="text_label_attestation_storage_type">Speichertyp</string>
+    <string name="text_label_attestation_storage_type">Schlüsselspeicher</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -545,6 +545,8 @@
     <string name="text_label_instance_attestation">Instance-Attestation</string>
     <string name="text_label_unit_attestation">Unit-Attestation</string>
     <string name="button_label_load_attestation">Attestation laden</string>
+    <string name="button_label_attestation_apply">Anwenden</string>
+    <string name="section_heading_attestation_certificates">Zertifikate</string>
     <string name="text_label_attestation_issued">Token gültig von</string>
     <string name="text_label_attestation_expiration">Token gültig bis</string>
     <string name="text_label_attestation_status_expiration">Status gültig bis</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -545,7 +545,10 @@
     <string name="text_label_instance_attestation">Instance-Attestation</string>
     <string name="text_label_unit_attestation">Unit-Attestation</string>
     <string name="button_label_load_attestation">Attestation laden</string>
-    <string name="text_label_attestation_issued">Gültig von</string>
-    <string name="text_label_attestation_expiration">Gültig bis</string>
+    <string name="text_label_attestation_issued">Token gültig von</string>
+    <string name="text_label_attestation_expiration">Token gültig bis</string>
+    <string name="text_label_attestation_status_expiration">Status gültig bis</string>
     <string name="text_label_attestation_storage_type">Schlüsselspeicher</string>
+    <string name="text_label_attestation_user_authentication">Authentifizierung</string>
+
 </resources>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -541,5 +541,5 @@
     <string name="button_label_load_attestation">Load attestation</string>
     <string name="text_label_attestation_issued">Issued</string>
     <string name="text_label_attestation_expiration">Expires</string>
-    <string name="text_label_attestation_storage_type">Storage type</string>
+    <string name="text_label_attestation_storage_type">Key storage</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -539,7 +539,10 @@
     <string name="text_label_instance_attestation">Instance attestation</string>
     <string name="text_label_unit_attestation">Unit attestation</string>
     <string name="button_label_load_attestation">Load attestation</string>
-    <string name="text_label_attestation_issued">Issued</string>
-    <string name="text_label_attestation_expiration">Expires</string>
+    <string name="text_label_attestation_issued">Token issued</string>
+    <string name="text_label_attestation_expiration">Token expires</string>
+    <string name="text_label_attestation_status_expiration">Status expires</string>
     <string name="text_label_attestation_storage_type">Key storage</string>
+    <string name="text_label_attestation_user_authentication">User authentication</string>
+
 </resources>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -55,6 +55,8 @@
     <string name="button_label_hide_technical_details">Hide technical details</string>
     <string name="button_label_sign">Sign</string>
     <string name="button_label_back">Back</string>
+    <string name="button_label_attestation_config">Attestation configuration</string>
+
 
     <string name="attribute_friendly_name_bpk">BPK</string>
     <string name="attribute_friendly_name_firstname">Given name</string>
@@ -250,6 +252,7 @@
     <string name="text_label_vcType">VcType</string>
     <string name="text_label_docType">DocType</string>
     <string name="text_label_select_no_optional_credential_set_query_option">Send nothing</string>
+    <string name="text_label_wallet_provider">Wallet provider</string>
 
     <string name="heading_label_credential_selection">Which Data should be used?</string>
     <string name="heading_label_authenticate_at_device_title">Authenticate</string>
@@ -275,6 +278,7 @@
     <string name="heading_label_show_qr_code_screen">Scan me!</string>
     <string name="heading_label_received_data">Received Data</string>
     <string name="heading_label_capabilities">Device capabilities</string>
+    <string name="heading_label_attestation">Attestation</string>
 
     <string name="heading_label_select_vda">Select VDA</string>
     <string name="heading_label_sign">Sign</string>
@@ -530,4 +534,12 @@
     <string name="success_reissued">Re-issued</string>
     <string name="error_reissue_failed">Re-issue failed</string>
     <string name="error_refresh_failed">Refresh failed</string>
+
+    <!-- AttestationSettings -->
+    <string name="text_label_instance_attestation">Instance attestation</string>
+    <string name="text_label_unit_attestation">Unit attestation</string>
+    <string name="button_label_load_attestation">Load attestation</string>
+    <string name="text_label_attestation_issued">Issued</string>
+    <string name="text_label_attestation_expiration">Expires</string>
+    <string name="text_label_attestation_storage_type">Storage type</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -539,6 +539,8 @@
     <string name="text_label_instance_attestation">Instance attestation</string>
     <string name="text_label_unit_attestation">Unit attestation</string>
     <string name="button_label_load_attestation">Load attestation</string>
+    <string name="button_label_attestation_apply">Apply</string>
+    <string name="section_heading_attestation_certificates">Certificates</string>
     <string name="text_label_attestation_issued">Token issued</string>
     <string name="text_label_attestation_expiration">Token expires</string>
     <string name="text_label_attestation_status_expiration">Status expires</string>

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/PresentationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/PresentationService.kt
@@ -3,27 +3,20 @@ package at.asitplus.wallet.app.common
 import at.asitplus.dcapi.DCAPIHandover
 import at.asitplus.dcapi.DCAPIHandover.Companion.TYPE_DCAPI
 import at.asitplus.dcapi.DCAPIInfo
-import at.asitplus.dcapi.request.DCAPIWalletRequest
-import at.asitplus.iso.DeviceAuthentication
-import at.asitplus.iso.SessionTranscript
-import at.asitplus.iso.serializeOrigin
-import at.asitplus.iso.sha256
-import at.asitplus.iso.wrapInCborTag
+import at.asitplus.iso.*
+import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
-import at.asitplus.wallet.lib.agent.CreatePresentationResult
-import at.asitplus.wallet.lib.agent.HolderAgent
-import at.asitplus.wallet.lib.agent.PresentationException
-import at.asitplus.wallet.lib.agent.PresentationRequestParameters
-import at.asitplus.wallet.lib.agent.PresentationResponseParameters
+import at.asitplus.wallet.lib.agent.*
 import at.asitplus.wallet.lib.cbor.CoseHeaderNone
 import at.asitplus.wallet.lib.cbor.SignCoseDetached
 import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.ktor.openid.OpenId4VpWallet
 import at.asitplus.wallet.lib.openid.AuthorizationResponsePreparationState
 import io.github.aakira.napier.Napier
-import io.ktor.client.HttpClient
+import io.ktor.client.*
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.encodeToByteArray
@@ -45,7 +38,7 @@ class PresentationService(
     suspend fun startAuthorizationResponsePreparation(input: String) =
         presentationService.startAuthorizationResponsePreparation(input)
 
-    suspend fun startAuthorizationResponsePreparation(input: DCAPIWalletRequest.OpenId4Vp) =
+    suspend fun startAuthorizationResponsePreparation(input: RequestParametersFrom<AuthenticationRequestParameters>) =
         presentationService.startAuthorizationResponsePreparation(input)
 
     suspend fun getMatchingCredentials(
@@ -63,13 +56,13 @@ class PresentationService(
     @OptIn(ExperimentalEncodingApi::class, ExperimentalStdlibApi::class)
     suspend fun finalizeDCAPIIsoMdocPresentation(
         credentialPresentation: CredentialPresentation.PresentationExchangePresentation,
-        isoMdocWalletRequest: DCAPIWalletRequest.IsoMdoc
+        isoMdocWalletRequest: RequestParametersFrom.IsoMdocDcApi
     ): OpenId4VpWallet.AuthenticationSuccess {
         Napier.d("Finalizing DCAPI response")
 
         // TODO this code is probably duplicated in the Verifier
         val hash = coseCompliantSerializer.encodeToByteArray(
-            DCAPIInfo(isoMdocWalletRequest.isoMdocRequest.encryptionInfo, isoMdocWalletRequest.callingOrigin)
+            DCAPIInfo(isoMdocWalletRequest.parameters.isoMdocRequest.encryptionInfo, isoMdocWalletRequest.callingOrigin)
         ).sha256()
         val handover = DCAPIHandover(type = TYPE_DCAPI, hash = hash)
         val sessionTranscript = SessionTranscript.forDcApi(handover)
@@ -78,7 +71,7 @@ class PresentationService(
 
         val presentationResult = holderAgent.createPresentation(
             request = PresentationRequestParameters(
-                nonce = isoMdocWalletRequest.isoMdocRequest.encryptionInfo.encryptionParameters.nonce
+                nonce = isoMdocWalletRequest.parameters.isoMdocRequest.encryptionInfo.encryptionParameters.nonce
                     ?.encodeToString(Base64UrlStrict) ?: throw IllegalArgumentException("no nonce"),
                 audience = callingOrigin,
                 calcIsoDeviceSignaturePlain = { input ->
@@ -118,7 +111,7 @@ class PresentationService(
         platformAdapter.prepareDCAPIIsoMdocCredentialResponse(
             deviceResponseSerialized,
             coseCompliantSerializer.encodeToByteArray(sessionTranscript),
-            isoMdocWalletRequest.isoMdocRequest.encryptionInfo.encryptionParameters
+            isoMdocWalletRequest.parameters.isoMdocRequest.encryptionInfo.encryptionParameters
         )
         return OpenId4VpWallet.AuthenticationSuccess()
     }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
@@ -1,6 +1,11 @@
 package at.asitplus.wallet.app.common
 
 import at.asitplus.openid.CredentialOffer
+import at.asitplus.openid.SupportedCredentialFormatIsoMdoc
+import at.asitplus.openid.SupportedCredentialFormatSdJwt
+import at.asitplus.openid.SupportedCredentialFormatW3cVcJsonLd
+import at.asitplus.openid.SupportedCredentialFormatW3cVcJwt
+import at.asitplus.openid.SupportedCredentialFormatW3cVcJwtJsonLd
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.app.common.attestation.AttestationService
 import at.asitplus.wallet.app.common.data.SettingsRepository
@@ -236,8 +241,12 @@ class ProvisioningService(
 }
 
 val CredentialIdentifierInfo.credentialScheme: ConstantIndex.CredentialScheme?
-    get() = with(supportedCredentialFormat) {
-        (credentialDefinition?.types?.firstNotNullOfOrNull { AttributeIndex.resolveAttributeType(it) }
-            ?: sdJwtVcType?.let { AttributeIndex.resolveSdJwtAttributeType(it) }
-            ?: docType?.let { AttributeIndex.resolveIsoDoctype(it) })
+    get() =  with(supportedCredentialFormat) {
+        when (this) {
+            is SupportedCredentialFormatIsoMdoc -> AttributeIndex.resolveIsoDoctype(docType)
+            is SupportedCredentialFormatSdJwt -> AttributeIndex.resolveSdJwtAttributeType(sdJwtVcType)
+            is SupportedCredentialFormatW3cVcJsonLd -> this.credentialDefinition.type.firstNotNullOfOrNull { AttributeIndex.resolveAttributeType(it) }
+            is SupportedCredentialFormatW3cVcJwt -> this.credentialDefinition.types.firstNotNullOfOrNull { AttributeIndex.resolveAttributeType(it) }
+            is SupportedCredentialFormatW3cVcJwtJsonLd -> this.credentialDefinition.type.firstNotNullOfOrNull { AttributeIndex.resolveAttributeType(it) }
+        }
     }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
@@ -2,36 +2,20 @@ package at.asitplus.wallet.app.common
 
 import at.asitplus.catching
 import at.asitplus.openid.CredentialOffer
-import at.asitplus.openid.OpenIdConstants
-import at.asitplus.signum.indispensable.asn1.Asn1Primitive
-import at.asitplus.signum.indispensable.asn1.Asn1String
-import at.asitplus.signum.indispensable.asn1.KnownOIDs
-import at.asitplus.signum.indispensable.asn1.commonName
-import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
-import at.asitplus.signum.indispensable.josef.JsonWebToken
-import at.asitplus.signum.indispensable.josef.JwsSigned
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
-import at.asitplus.signum.indispensable.pki.AttributeTypeAndValue
-import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.wallet.app.common.attestation.AttestationService
 import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
-import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.data.AttributeIndex
 import at.asitplus.wallet.lib.data.ConstantIndex
-import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
-import at.asitplus.wallet.lib.jws.JwsHeaderNone
-import at.asitplus.wallet.lib.jws.SignJwt
+import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.ktor.openid.CredentialIdentifierInfo
 import at.asitplus.wallet.lib.ktor.openid.CredentialIssuanceResult
 import at.asitplus.wallet.lib.ktor.openid.OAuth2KtorClient
 import at.asitplus.wallet.lib.ktor.openid.OpenId4VciClient
 import at.asitplus.wallet.lib.ktor.openid.ProvisioningContext
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
-import at.asitplus.wallet.lib.oidvci.BuildClientAttestationJwt
-import at.asitplus.wallet.lib.oidvci.BuildClientAttestationPoPJwt
 import at.asitplus.wallet.lib.oidvci.WalletService
 import data.storage.DataStoreService
 import data.storage.PersistentCookieStorage
@@ -46,8 +30,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
 import ui.navigation.IntentService
-import kotlin.time.Clock.System
-import kotlin.time.Duration.Companion.minutes
 
 
 class ProvisioningService(
@@ -67,7 +49,6 @@ class ProvisioningService(
     private val redirectUrl = "asitplus-wallet://wallet.a-sit.at/app/callback/provisioning"
     private var cachedClientId: String? = null
 
-    private var instanceAttestationJwt = null as JwsSigned<JsonWebToken>?
     private var openId4VciClientCached = null as OpenId4VciClient?
     private var walletServiceCached = null as WalletService?
 
@@ -75,20 +56,10 @@ class ProvisioningService(
         val clientId = config.clientId.first()
         if (clientId != cachedClientId) {
             cachedClientId = clientId
-            instanceAttestationJwt = null
             openId4VciClientCached = null
+            walletServiceCached = null
         }
         return clientId
-    }
-
-    private suspend fun instanceAttestationJwt() = instanceAttestationJwt ?: BuildClientAttestationJwt(
-        SignJwt(keyMaterial, JwsHeaderCertOrJwk()),
-        clientId = currentClientId(),
-        issuer = keyMaterial.getCertificate()?.extractSubjectCn() ?: "https://example.com",
-        lifetime = 60.minutes,
-        clientKey = keyMaterial.jsonWebKey
-    ).also {
-        instanceAttestationJwt = it
     }
 
     private suspend fun walletService(): WalletService = walletServiceCached ?: run {
@@ -96,32 +67,7 @@ class ProvisioningService(
         WalletService(
             clientId = clientId,
             keyMaterial = keyMaterial,
-            loadUnitAttestationPop = { input ->
-                with(EphemeralKeyWithSelfSignedCert()) {
-                    catching {
-                        SignJwt<KeyAttestationJwt>(this, JwsHeaderCertOrJwk())(
-                            OpenIdConstants.KEY_ATTESTATION_JWT_TYPE,
-                            KeyAttestationJwt(
-                                issuedAt = System.now(),
-                                nonce = input.payload.nonce,
-                                attestedKeys = setOf(keyMaterial.jsonWebKey)
-                            ),
-                            KeyAttestationJwt.serializer(),
-                        ).getOrThrow().let { unitAttestation ->
-                            SignJwt<JsonWebToken>(keyMaterial) { header, material ->
-                                header.copy(
-                                    keyAttestation = unitAttestation.serialize(),
-                                    jsonWebKey = material.jsonWebKey
-                                )
-                            }.invoke(
-                                input.type,
-                                input.payload,
-                                JsonWebToken.serializer(),
-                            ).getOrThrow()
-                        }
-                    }
-                }
-            },
+            loadKeyAttestation = attestationService::loadKeyAttestation,
             remoteResourceRetriever = { data ->
                 withContext(Dispatchers.IO) {
                     client.get(data.url).bodyAsText()
@@ -140,17 +86,8 @@ class ProvisioningService(
                 cookiesStorage = cookieStorage,
                 oAuth2Client = OAuth2Client(clientId = currentClientId(), redirectUrl = redirectUrl),
                 httpClientConfig = httpService.loggingConfig,
-                loadInstanceAttestation = { catching { instanceAttestationJwt() } },
-                loadInstanceAttestationPop = {
-                    catching {
-                        BuildClientAttestationPoPJwt(
-                            SignJwt(keyMaterial, JwsHeaderNone()),
-                            clientId = currentClientId(),
-                            audience = config.host.first(),
-                            lifetime = 10.minutes,
-                        )
-                    }
-                },
+                loadInstanceAttestation = attestationService::loadInstanceAttestation,
+                loadInstanceAttestationPop = { attestationService.loadInstanceAttestationPop() },
             ),
             oid4vciService = walletService()
         ).also { openId4VciClientCached = it }
@@ -285,14 +222,6 @@ class ProvisioningService(
         }
     }
 
-    private fun X509Certificate.extractSubjectCn(): String? =
-        firstSubjectName()?.commonName()?.let { Asn1String.doDecode(it) }?.value
-
-    private fun X509Certificate.firstSubjectName(): List<AttributeTypeAndValue>? =
-        tbsCertificate.subjectName.firstOrNull()?.attrsAndValues
-
-    private fun List<AttributeTypeAndValue>?.commonName(): Asn1Primitive? =
-        this?.find { it.oid == KnownOIDs.commonName }?.value as? Asn1Primitive
 }
 
 val CredentialIdentifierInfo.credentialScheme: ConstantIndex.CredentialScheme?

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
@@ -86,7 +86,7 @@ class ProvisioningService(
                 oAuth2Client = OAuth2Client(clientId = currentClientId(), redirectUrl = redirectUrl),
                 httpClientConfig = httpService.loggingConfig,
                 loadInstanceAttestation = attestationService::loadInstanceAttestation,
-                keyMaterial = attestationService.instanceAttestationHelper.instanceAttestationKeyMaterial()
+                keyMaterial = attestationService.getInstanceAttestationKeyMaterial()
             ),
             oid4vciService = walletService()
         ).also { openId4VciClientCached = it }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
@@ -1,7 +1,7 @@
 package at.asitplus.wallet.app.common
 
-import at.asitplus.catching
 import at.asitplus.openid.CredentialOffer
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.app.common.attestation.AttestationService
 import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
@@ -9,7 +9,6 @@ import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.data.AttributeIndex
 import at.asitplus.wallet.lib.data.ConstantIndex
-import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.ktor.openid.CredentialIdentifierInfo
 import at.asitplus.wallet.lib.ktor.openid.CredentialIssuanceResult
 import at.asitplus.wallet.lib.ktor.openid.OAuth2KtorClient
@@ -41,7 +40,7 @@ class ProvisioningService(
     private val config: SettingsRepository,
     private val errorService: ErrorService,
     private val httpService: HttpService,
-    private val attestationService: AttestationService,
+    private val attestationService: AttestationService
 ) {
     private val cookieStorage = PersistentCookieStorage(dataStoreService, errorService)
     private val client = httpService.buildHttpClient(cookieStorage = cookieStorage)
@@ -66,8 +65,8 @@ class ProvisioningService(
         val clientId = currentClientId()
         WalletService(
             clientId = clientId,
-            keyMaterial = keyMaterial,
             loadKeyAttestation = attestationService::loadKeyAttestation,
+            keyMaterial = keyMaterial,
             remoteResourceRetriever = { data ->
                 withContext(Dispatchers.IO) {
                     client.get(data.url).bodyAsText()
@@ -87,7 +86,7 @@ class ProvisioningService(
                 oAuth2Client = OAuth2Client(clientId = currentClientId(), redirectUrl = redirectUrl),
                 httpClientConfig = httpService.loggingConfig,
                 loadInstanceAttestation = attestationService::loadInstanceAttestation,
-                loadInstanceAttestationPop = { attestationService.loadInstanceAttestationPop() },
+                keyMaterial = attestationService.instanceAttestationHelper.instanceAttestationKeyMaterial()
             ),
             oid4vciService = walletService()
         ).also { openId4VciClientCached = it }
@@ -164,7 +163,11 @@ class ProvisioningService(
     }
 
     @Throws(Throwable::class)
-    suspend fun refreshCredential(renewalInfo: CredentialRenewalInfo, oldCredentialId: StoreEntryId, statusUpdater: ((Long, RefreshStatus) -> Unit)) {
+    suspend fun refreshCredential(
+        renewalInfo: CredentialRenewalInfo,
+        oldCredentialId: StoreEntryId,
+        statusUpdater: ((Long, RefreshStatus) -> Unit)
+    ) {
         Napier.d("refreshCredential with identifier ${renewalInfo.credentialIdentifier}")
         openId4VciClient().refreshCredentialReturningResult(renewalInfo).getOrThrow().also { result ->
             val storageResults = result.credentials.map { credentialInput ->

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
@@ -55,10 +55,15 @@ class ProvisioningService(
         val clientId = config.clientId.first()
         if (clientId != cachedClientId) {
             cachedClientId = clientId
-            openId4VciClientCached = null
-            walletServiceCached = null
+            clearCaches()
         }
         return clientId
+    }
+
+    private suspend fun clearCaches() {
+        attestationService.reset()
+        openId4VciClientCached = null
+        walletServiceCached = null
     }
 
     private suspend fun walletService(): WalletService = walletServiceCached ?: run {
@@ -108,6 +113,7 @@ class ProvisioningService(
         credentialIdentifierInfo: CredentialIdentifierInfo,
         reissuingStoreEntryId: StoreEntryId? = null
     ) {
+        clearCaches()
         config.set(host = credentialIssuer)
         cookieStorage.reset()
         openId4VciClient().startProvisioningWithAuthRequestReturningResult(
@@ -168,6 +174,7 @@ class ProvisioningService(
         oldCredentialId: StoreEntryId,
         statusUpdater: ((Long, RefreshStatus) -> Unit)
     ) {
+        clearCaches()
         Napier.d("refreshCredential with identifier ${renewalInfo.credentialIdentifier}")
         openId4VciClient().refreshCredentialReturningResult(renewalInfo).getOrThrow().also { result ->
             val storageResults = result.credentials.map { credentialInput ->
@@ -193,6 +200,7 @@ class ProvisioningService(
     suspend fun decodeCredentialOffer(
         qrCodeContent: String
     ): CredentialOffer {
+        clearCaches()
         return walletService().parseCredentialOffer(qrCodeContent).getOrThrow()
     }
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/ProvisioningService.kt
@@ -13,6 +13,7 @@ import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.AttributeTypeAndValue
 import at.asitplus.signum.indispensable.pki.X509Certificate
+import at.asitplus.wallet.app.common.attestation.AttestationService
 import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
@@ -58,6 +59,7 @@ class ProvisioningService(
     private val config: SettingsRepository,
     private val errorService: ErrorService,
     private val httpService: HttpService,
+    private val attestationService: AttestationService,
 ) {
     private val cookieStorage = PersistentCookieStorage(dataStoreService, errorService)
     private val client = httpService.buildHttpClient(cookieStorage = cookieStorage)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletConfig.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletConfig.kt
@@ -24,7 +24,7 @@ class WalletConfig(
     private val config: Flow<ConfigData> =
         dataStoreService.getPreference(Configuration.DATASTORE_KEY_CONFIG).map {
             it?.let {
-                vckJsonSerializer.decodeFromString<ConfigData>(it)
+                joseCompliantSerializer.decodeFromString<ConfigData>(it)
             } ?: ConfigData()
         }
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletConfig.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletConfig.kt
@@ -133,7 +133,7 @@ class WalletConfig(
 private data class ConfigData(
     val clientId: String = SettingsRepository.DEFAULT_CLIENT_ID,
     val host: String = "https://wallet.a-sit.at/m7",
-    val walletProviderHost: String = "https://wallet.a-sit.at/provider", // TODO: change to correct host
+    val walletProviderHost: String = "https://wallet-provider.a-sit.plus",
     val isConditionsAccepted: Boolean = false,
     val presentmentUseNegotiatedHandover: Boolean = true,
     val presentmentBleCentralClientModeEnabled: Boolean = true,

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletConfig.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletConfig.kt
@@ -23,8 +23,9 @@ class WalletConfig(
 ) : SettingsRepository {
     private val config: Flow<ConfigData> =
         dataStoreService.getPreference(Configuration.DATASTORE_KEY_CONFIG).map {
-            it?.let { joseCompliantSerializer.decodeFromString<ConfigData>(it) }
-                ?: ConfigDataDefaults
+            it?.let {
+                vckJsonSerializer.decodeFromString<ConfigData>(it)
+            } ?: ConfigData()
         }
 
     override val host: Flow<String> = config.map {
@@ -33,6 +34,7 @@ class WalletConfig(
     }
     override val clientId: Flow<String> = config.map { it.clientId }
 
+    override val walletProviderHost = config.map { it.walletProviderHost }
     override val isConditionsAccepted: Flow<Boolean> = config.map { it.isConditionsAccepted }
     override val presentmentUseNegotiatedHandover: Flow<Boolean> = config.map { it.presentmentUseNegotiatedHandover }
     override val presentmentBleCentralClientModeEnabled: Flow<Boolean> = config.map { it.presentmentBleCentralClientModeEnabled }
@@ -47,6 +49,7 @@ class WalletConfig(
     override fun set(
         host: String?,
         clientId: String?,
+        walletProviderHost: String?,
         isConditionsAccepted: Boolean?,
         presentmentUseNegotiatedHandover: Boolean?,
         presentmentBleCentralClientModeEnabled: Boolean?,
@@ -63,6 +66,7 @@ class WalletConfig(
             val newConfig = ConfigData(
                 host = host ?: this@WalletConfig.host.first(),
                 clientId = clientId ?: this@WalletConfig.clientId.first(),
+                walletProviderHost = walletProviderHost ?: this@WalletConfig.walletProviderHost.first(),
                 isConditionsAccepted = isConditionsAccepted
                     ?: this@WalletConfig.isConditionsAccepted.first(),
                 presentmentUseNegotiatedHandover = presentmentUseNegotiatedHandover
@@ -127,8 +131,9 @@ class WalletConfig(
  */
 @Serializable
 private data class ConfigData(
-    val host: String,
     val clientId: String = SettingsRepository.DEFAULT_CLIENT_ID,
+    val host: String = "https://wallet.a-sit.at/m7",
+    val walletProviderHost: String = "https://wallet.a-sit.at/provider", // TODO: change to correct host
     val isConditionsAccepted: Boolean = false,
     val presentmentUseNegotiatedHandover: Boolean = true,
     val presentmentBleCentralClientModeEnabled: Boolean = true,
@@ -139,10 +144,4 @@ private data class ConfigData(
     val presentmentAllowMultipleRequests: Boolean = false,
     val readerAutomaticallySelectTransport: Boolean = true,
     val connectionTimeout: Duration = 15.seconds,
-)
-
-private val ConfigDataDefaults = ConfigData(
-    host = "https://wallet.a-sit.at/m7",
-    clientId = SettingsRepository.DEFAULT_CLIENT_ID,
-    isConditionsAccepted = false,
 )

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
@@ -7,6 +7,7 @@ import at.asitplus.iso.EncryptionParameters
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.snackbar_update_action
 import at.asitplus.valera.resources.snackbar_update_hint
+import at.asitplus.wallet.app.common.attestation.AttestationService
 import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.app.common.dcapi.DCAPIExportService
 import at.asitplus.wallet.app.common.dcapi.data.export.CredentialRegistry
@@ -59,6 +60,7 @@ class WalletMain(
     val sessionService: SessionService,
     val capabilitiesService: CapabilitiesService,
     val credentialValidityService: CredentialValidityService,
+    val attestationService: AttestationService,
 ) {
     val appReady = MutableStateFlow<Boolean?>(null)
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
@@ -2,8 +2,8 @@ package at.asitplus.wallet.app.common
 
 import at.asitplus.KmmResult
 import at.asitplus.catchingUnwrapped
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.iso.EncryptionParameters
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.snackbar_update_action
 import at.asitplus.valera.resources.snackbar_update_hint
@@ -18,17 +18,12 @@ import at.asitplus.wallet.lib.ktor.openid.CredentialIdentifierInfo
 import data.storage.DataStoreService
 import data.storage.WalletSubjectCredentialStore
 import io.github.aakira.napier.Napier
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -235,7 +230,7 @@ interface PlatformAdapter {
     /**
      * Retrieves request from the digital credentials browser API
      */
-    fun getCurrentDCAPIData(): KmmResult<DCAPIWalletRequest>
+    fun getCurrentDCAPIVerificationData(): KmmResult<RequestParametersFrom.DcApiRequest>
 
     fun prepareDCAPIIsoMdocCredentialResponse(
         responseJson: ByteArray,
@@ -271,7 +266,7 @@ class DummyPlatformAdapter : PlatformAdapter {
     override fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
     }
 
-    override fun getCurrentDCAPIData(): KmmResult<DCAPIWalletRequest> {
+    override fun getCurrentDCAPIVerificationData(): KmmResult<RequestParametersFrom.DcApiRequest> {
         return KmmResult.failure(IllegalStateException("Using dummy platform adapter"))
     }
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -13,8 +13,12 @@ import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.lib.agent.SignerBasedKeyMaterial
 import at.asitplus.wallet.lib.oidvci.WalletService.LoadUnitAttestationPopInput
 import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -30,6 +34,8 @@ class AttestationService(
     val unitAttestationHelper = UnitAttestationHelper(config.walletProviderHost, httpService, keyMaterial)
     var bufferedInstanceAttestation = MutableStateFlow<JwsSigned<JsonWebToken>?>(null)
     var bufferedUnitAttestation = MutableStateFlow<JwsSigned<KeyAttestationJwt>?>(null)
+
+    private val scope = CoroutineScope(Dispatchers.IO)
 
     suspend fun preloadAttestation() = catching {
         Napier.d("AttestationService: Preload attestation")
@@ -63,7 +69,11 @@ class AttestationService(
 
 
     fun getWalletProviderHost() = config.walletProviderHost
-    fun setWalletProviderHost(host: String) = config.set(walletProviderHost = host)
+    fun setWalletProviderHost(host: String) = scope.launch {
+        config.set(walletProviderHost = host)
+        bufferedUnitAttestation.emit(null)
+        bufferedInstanceAttestation.emit(null)
+    }
 
     private suspend fun requestInstanceAttestation(): JwsSigned<JsonWebToken> {
         bufferedInstanceAttestation.firstOrNull()?.let { buffer ->

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -55,8 +55,9 @@ class AttestationService(
 
     suspend fun loadUnitAttestationPop(input: LoadUnitAttestationPopInput) = catching {
         requestUnitAttestation(input.ttl).let { unitAttestation ->
-            bufferedUnitAttestation.emit(null)
-            unitAttestationHelper.buildProofOfPossession(unitAttestation, input.type, input.payload)
+            unitAttestationHelper.buildProofOfPossession(unitAttestation, input.type, input.payload).also {
+                bufferedUnitAttestation.emit(unitAttestation)
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -11,7 +11,7 @@ import at.asitplus.wallet.app.common.HttpService
 import at.asitplus.wallet.app.common.WalletKeyMaterial
 import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.lib.agent.SignerBasedKeyMaterial
-import at.asitplus.wallet.lib.oidvci.WalletService.LoadUnitAttestationPopInput
+import at.asitplus.wallet.lib.oidvci.WalletService.KeyAttestationInput
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -59,11 +59,9 @@ class AttestationService(
         instanceAttestationHelper.buildProofOfPossession(nonce)
     }
 
-    suspend fun loadUnitAttestationPop(input: LoadUnitAttestationPopInput) = catching {
-        requestUnitAttestation(input.ttl).let { unitAttestation ->
-            unitAttestationHelper.buildProofOfPossession(unitAttestation, input.type, input.payload).also {
-                bufferedUnitAttestation.emit(unitAttestation)
-            }
+    suspend fun loadKeyAttestation(input: KeyAttestationInput) = catching {
+        requestUnitAttestation(input).also {
+            bufferedUnitAttestation.emit(null)
         }
     }
 
@@ -90,11 +88,19 @@ class AttestationService(
     }
 
     private suspend fun requestUnitAttestation(
-        ttl: Duration = 31.days
+        input: KeyAttestationInput = KeyAttestationInput(
+            credentialIssuer = null,
+            clientNonce = null,
+            supportedAlgorithms = null,
+            preferredKeyStorageStatusPeriod = 31.days,
+        ),
     ): JwsSigned<KeyAttestationJwt> {
+        val preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod ?: 31.days
+
         bufferedUnitAttestation.firstOrNull()?.let { buffer ->
-            if ((buffer.payload.expiration)?.let { it > Clock.System.now() + ttl } == true) {
+            if (buffer.hasRemainingKeyStorageStatusPeriod(preferredKeyStorageStatusPeriod)) {
                 Napier.d("AttestationService: Use buffered unit attestation")
+                bufferedUnitAttestation.emit(null)
                 return buffer
             }
         }
@@ -104,7 +110,13 @@ class AttestationService(
         val instanceAttestation = requestInstanceAttestation()
         val pop = instanceAttestationHelper.buildProofOfPossession()
 
-        return unitAttestationHelper.requestUnitAttestation(instanceAttestation, pop)
+        return unitAttestationHelper.requestUnitAttestation(instanceAttestation, pop, input)
+    }
+
+    private fun JwsSigned<KeyAttestationJwt>.hasRemainingKeyStorageStatusPeriod(ttl: Duration): Boolean {
+        val now = Clock.System.now()
+        return payload.expiration?.let { it > now + 10.seconds } == true &&
+                payload.keyStorageStatus?.expiration?.let { it > now + ttl } == true
     }
 }
 

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -1,0 +1,104 @@
+package at.asitplus.wallet.app.common.attestation
+
+import at.asitplus.catching
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
+import at.asitplus.signum.indispensable.pki.X509Certificate
+import at.asitplus.signum.supreme.sign.Signer
+import at.asitplus.wallet.app.common.BuildContext
+import at.asitplus.wallet.app.common.HttpService
+import at.asitplus.wallet.app.common.WalletKeyMaterial
+import at.asitplus.wallet.app.common.data.SettingsRepository
+import at.asitplus.wallet.lib.agent.SignerBasedKeyMaterial
+import at.asitplus.wallet.lib.oidvci.WalletService.LoadUnitAttestationPopInput
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
+
+class AttestationService(
+    val keyMaterial: WalletKeyMaterial,
+    private val config: SettingsRepository,
+    private val buildContext: BuildContext,
+    httpService: HttpService
+) {
+    val instanceAttestationHelper = InstanceAttestationHelper(config.walletProviderHost, httpService)
+    val unitAttestationHelper = UnitAttestationHelper(config.walletProviderHost, httpService, keyMaterial)
+    var bufferedInstanceAttestation = MutableStateFlow<JwsSigned<JsonWebToken>?>(null)
+    var bufferedUnitAttestation = MutableStateFlow<JwsSigned<KeyAttestationJwt>?>(null)
+
+    suspend fun preloadAttestation() = catching {
+        Napier.d("AttestationService: Preload attestation")
+        requestInstanceAttestation().let {
+            bufferedInstanceAttestation.emit(it)
+        }
+        requestUnitAttestation().let {
+            bufferedUnitAttestation.emit(it)
+        }
+    }
+
+    suspend fun loadInstanceAttestation() = catching {
+        requestInstanceAttestation().let { instanceAttestation ->
+            bufferedInstanceAttestation.emit(null)
+            instanceAttestation
+        }
+    }
+
+
+    suspend fun loadInstanceAttestationPop(nonce: String? = null) = catching {
+        instanceAttestationHelper.buildProofOfPossession(nonce)
+    }
+
+    suspend fun loadUnitAttestationPop(input: LoadUnitAttestationPopInput) = catching {
+        requestUnitAttestation(input.ttl).let { unitAttestation ->
+            bufferedUnitAttestation.emit(null)
+            unitAttestationHelper.buildProofOfPossession(unitAttestation, input.type, input.payload)
+        }
+    }
+
+
+    fun getWalletProviderHost() = config.walletProviderHost
+    fun setWalletProviderHost(host: String) = config.set(walletProviderHost = host)
+
+    private suspend fun requestInstanceAttestation(): JwsSigned<JsonWebToken> {
+        bufferedInstanceAttestation.firstOrNull()?.let { buffer ->
+            if ((buffer.payload.expiration)?.let { it > Clock.System.now() + 10.seconds } == true) {
+                Napier.d("AttestationService: Use buffered instance attestation")
+                return buffer
+            }
+        }
+
+        Napier.d("AttestationService: Request new instance attestation")
+        val instanceAttestation = instanceAttestationHelper.requestInstanceAttestation(buildContext.versionName)
+        bufferedInstanceAttestation.emit(instanceAttestation)
+        return instanceAttestation
+    }
+
+    private suspend fun requestUnitAttestation(
+        ttl: Duration = 31.days
+    ): JwsSigned<KeyAttestationJwt> {
+        bufferedUnitAttestation.firstOrNull()?.let { buffer ->
+            if ((buffer.payload.expiration)?.let { it > Clock.System.now() + ttl } == true) {
+                Napier.d("AttestationService: Use buffered unit attestation")
+                return buffer
+            }
+        }
+
+        Napier.d("AttestationService: Request new unit attestation")
+
+        val instanceAttestation = requestInstanceAttestation()
+        val pop = instanceAttestationHelper.buildProofOfPossession()
+
+        return unitAttestationHelper.requestUnitAttestation(instanceAttestation, pop)
+    }
+}
+
+class HolderKeyMaterial(
+    signer: Signer,
+) : SignerBasedKeyMaterial(signer) {
+    override suspend fun getCertificate(): X509Certificate? = null
+}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -1,9 +1,10 @@
 package at.asitplus.wallet.app.common.attestation
 
+import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.ClientNonceResponse
 import at.asitplus.signum.indispensable.josef.JsonWebToken
-import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
 import at.asitplus.wallet.app.common.BuildContext
 import at.asitplus.wallet.app.common.HttpService
@@ -26,36 +27,36 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 
 class AttestationService(
     holderKey: WalletKeyMaterial,
     private val config: SettingsRepository,
     buildContext: BuildContext,
-    httpService: HttpService
+    httpService: HttpService,
 ) {
-    val httpClient = httpService.buildHttpClient()
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private val httpClient = httpService.buildHttpClient()
 
-    val challengeEndpoint = config.walletProviderHost.map {
+    private val challengeEndpoint = config.walletProviderHost.map {
         URLBuilder(it).apply {
             appendEncodedPathSegments(PATH_NONCE)
         }
     }
 
-    val instanceAttestationHelper = InstanceAttestationHelper(
+    private val instanceAttestationHelper = InstanceAttestationHelper(
         config.walletProviderHost,
         httpClient,
-        buildContext
+        buildContext,
     )
-    
-    val keyAttestationHelper = KeyAttestationHelper(config.walletProviderHost, httpClient, holderKey)
-    val bufferedInstanceAttestation = MutableStateFlow<JwsSigned<JsonWebToken>?>(null)
-    val bufferedKeyAttestation = MutableStateFlow<JwsSigned<KeyAttestationJwt>?>(null)
 
-    private val scope = CoroutineScope(Dispatchers.IO)
+    private val keyAttestationHelper = KeyAttestationHelper(config.walletProviderHost, httpClient, holderKey)
+    val bufferedInstanceAttestation = MutableStateFlow<JwsCompactTyped<JsonWebToken>?>(null)
+    val bufferedKeyAttestation = MutableStateFlow<JwsCompactTyped<KeyAttestationJwt>?>(null)
 
-    suspend fun preloadInstanceAttestation() = catching {
+    suspend fun getInstanceAttestationKeyMaterial() = instanceAttestationHelper.keyMaterial()
+
+    suspend fun preloadInstanceAttestation() = runCatching {
         Napier.d("AttestationService: Preload instance attestation")
         requestInstanceAttestation().let {
             bufferedInstanceAttestation.emit(it)
@@ -63,7 +64,8 @@ class AttestationService(
     }.onFailure {
         Napier.e("AttestationService: Error preloading instance attestation. $it")
     }
-    suspend fun preloadKeyAttestation() = catching {
+
+    suspend fun preloadKeyAttestation() = runCatching {
         Napier.d("AttestationService: Preload key attestation")
         requestKeyAttestation(
             KeyAttestationInput(
@@ -80,18 +82,18 @@ class AttestationService(
     }
 
     suspend fun loadInstanceAttestation(input: LoadInstanceAttestationInput) = catching {
-        requestInstanceAttestation(input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL).let { instanceAttestation ->
-            bufferedInstanceAttestation.emit(null)
-            instanceAttestation
-        }
+        requestInstanceAttestation(
+            input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL
+        )
     }
 
-    suspend fun loadKeyAttestation(input: KeyAttestationInput) = catching {
-        if (input.clientNonce != null) bufferedKeyAttestation.emit(null)
-        requestKeyAttestation(input).also { keyAttestation ->
-            bufferedKeyAttestation.emit(keyAttestation)
+    suspend fun loadKeyAttestation(input: KeyAttestationInput): KmmResult<JwsCompactTyped<KeyAttestationJwt>> =
+        catching {
+            if (!input.allowBuffer()) bufferedKeyAttestation.emit(null)
+            requestKeyAttestation(input).also { keyAttestation ->
+                bufferedKeyAttestation.emit(keyAttestation)
+            }
         }
-    }
 
     fun getWalletProviderHost() = config.walletProviderHost
     fun setWalletProviderHost(host: String) = scope.launch {
@@ -102,7 +104,7 @@ class AttestationService(
 
     private suspend fun requestInstanceAttestation(
         preferredClientStatusPeriod: Duration = PREFERRED_DEFAULT_TTL
-    ): JwsSigned<JsonWebToken> {
+    ): JwsCompactTyped<JsonWebToken> {
         bufferedInstanceAttestation.firstOrNull()?.let { buffer ->
             if (buffer.hasRemainingClientStatusPeriod(preferredClientStatusPeriod)) {
                 Napier.d("AttestationService: Use buffered instance attestation")
@@ -111,14 +113,14 @@ class AttestationService(
         }
 
         Napier.d("AttestationService: Request new instance attestation")
-        val instanceAttestation = instanceAttestationHelper.requestInstanceAttestation(preferredClientStatusPeriod)
+        val instanceAttestation = instanceAttestationHelper.instanceAttestation(preferredClientStatusPeriod)
         bufferedInstanceAttestation.emit(instanceAttestation)
         return instanceAttestation
     }
 
     private suspend fun requestKeyAttestation(
         input: KeyAttestationInput,
-    ): JwsSigned<KeyAttestationJwt> {
+    ): JwsCompactTyped<KeyAttestationJwt> {
         val preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod ?: PREFERRED_DEFAULT_TTL
 
         bufferedKeyAttestation.firstOrNull()?.let { buffer ->
@@ -147,19 +149,19 @@ class AttestationService(
         )
     }
 
-    private fun JwsSigned<KeyAttestationJwt>.hasRemainingKeyStorageStatusPeriod(ttl: Duration): Boolean {
+    private fun JwsCompactTyped<KeyAttestationJwt>.hasRemainingKeyStorageStatusPeriod(ttl: Duration): Boolean {
         val now = Clock.System.now()
         return payload.expiration?.let { it > now + 10.seconds } == true &&
                 payload.keyStorageStatus?.expiration?.let { it > now + ttl } == true
     }
 
-    private fun JwsSigned<JsonWebToken>.hasRemainingClientStatusPeriod(ttl: Duration): Boolean {
+    private fun JwsCompactTyped<JsonWebToken>.hasRemainingClientStatusPeriod(ttl: Duration): Boolean {
         val now = Clock.System.now()
         return payload.expiration?.let { it > now + 10.seconds } == true &&
                 payload.clientStatus?.expiration?.let { it > now + ttl } == true
     }
 
-    private suspend fun getChallenge() = catching {
+    private suspend fun getChallenge() = runCatching {
         httpClient.get(challengeEndpoint.first().build()) {
         }.body<ClientNonceResponse>().clientNonce
     }.onFailure {
@@ -167,3 +169,5 @@ class AttestationService(
     }.getOrNull()
 
 }
+
+fun KeyAttestationInput.allowBuffer() = (this.credentialIssuer == null && this.clientNonce == null)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.app.common.attestation
 
+import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.ClientNonceResponse
 import at.asitplus.signum.indispensable.josef.JsonWebToken
@@ -80,19 +81,18 @@ class AttestationService(
         Napier.e("AttestationService: Error preloading key attestation. $it")
     }
 
-    suspend fun loadInstanceAttestation(input: LoadInstanceAttestationInput) = catchingUnwrapped {
+    suspend fun loadInstanceAttestation(input: LoadInstanceAttestationInput) = catching {
         requestInstanceAttestation(
             input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL
         )
     }
 
-    suspend fun loadKeyAttestation(input: KeyAttestationInput): Result<JwsCompactTyped<KeyAttestationJwt>> =
-        catchingUnwrapped {
-            if (!input.allowBuffer()) bufferedKeyAttestation.emit(null)
-            requestKeyAttestation(input).also { keyAttestation ->
-                bufferedKeyAttestation.emit(keyAttestation)
-            }
+    suspend fun loadKeyAttestation(input: KeyAttestationInput) = catching {
+        if (!input.allowBuffer()) bufferedKeyAttestation.emit(null)
+        requestKeyAttestation(input).also { keyAttestation ->
+            bufferedKeyAttestation.emit(keyAttestation)
         }
+    }
 
     fun getWalletProviderHost() = config.walletProviderHost
     fun setWalletProviderHost(host: String) = scope.launch {
@@ -135,8 +135,7 @@ class AttestationService(
         val instanceAttestation = requestInstanceAttestation()
 
         val pop = instanceAttestationHelper.buildProofOfPossession(
-            audience = config.walletProviderHost.first(),
-            nonce = getChallenge()
+            audience = config.walletProviderHost.first(), nonce = getChallenge()
         )
 
         return keyAttestationHelper.requestKeyAttestation(
@@ -150,19 +149,16 @@ class AttestationService(
 
     private fun JwsCompactTyped<KeyAttestationJwt>.hasRemainingKeyStorageStatusPeriod(ttl: Duration): Boolean {
         val now = Clock.System.now()
-        return payload.expiration?.let { it > now + 10.seconds } == true &&
-                payload.keyStorageStatus?.expiration?.let { it > now + ttl } == true
+        return payload.expiration?.let { it > now + 10.seconds } == true && payload.keyStorageStatus?.expiration?.let { it > now + ttl } == true
     }
 
     private fun JwsCompactTyped<JsonWebToken>.hasRemainingClientStatusPeriod(ttl: Duration): Boolean {
         val now = Clock.System.now()
-        return payload.expiration?.let { it > now + 10.seconds } == true &&
-                payload.clientStatus?.expiration?.let { it > now + ttl } == true
+        return payload.expiration?.let { it > now + 10.seconds } == true && payload.clientStatus?.expiration?.let { it > now + ttl } == true
     }
 
     private suspend fun getChallenge() = catchingUnwrapped {
-        httpClient.get(challengeEndpoint.first().build()) {
-        }.body<ClientNonceResponse>().clientNonce
+        httpClient.get(challengeEndpoint.first().build()) {}.body<ClientNonceResponse>().clientNonce
     }.onFailure {
         Napier.e("AttestationService: Error receiving challenge. $it")
     }.getOrNull()

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -87,6 +87,7 @@ class AttestationService(
     }
 
     suspend fun loadKeyAttestation(input: KeyAttestationInput) = catching {
+        if (input.clientNonce != null) bufferedKeyAttestation.emit(null)
         requestKeyAttestation(input).also { keyAttestation ->
             bufferedKeyAttestation.emit(keyAttestation)
         }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -1,23 +1,28 @@
 package at.asitplus.wallet.app.common.attestation
 
 import at.asitplus.catching
+import at.asitplus.openid.ClientNonceResponse
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
-import at.asitplus.signum.indispensable.pki.X509Certificate
-import at.asitplus.signum.supreme.sign.Signer
 import at.asitplus.wallet.app.common.BuildContext
 import at.asitplus.wallet.app.common.HttpService
 import at.asitplus.wallet.app.common.WalletKeyMaterial
 import at.asitplus.wallet.app.common.data.SettingsRepository
-import at.asitplus.wallet.lib.agent.SignerBasedKeyMaterial
+import at.asitplus.wallet.lib.ktor.openid.OAuth2KtorClient.LoadInstanceAttestationInput
 import at.asitplus.wallet.lib.oidvci.WalletService.KeyAttestationInput
 import io.github.aakira.napier.Napier
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.URLBuilder
+import io.ktor.http.appendEncodedPathSegments
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -25,92 +30,120 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 
 class AttestationService(
-    val keyMaterial: WalletKeyMaterial,
+    holderKey: WalletKeyMaterial,
     private val config: SettingsRepository,
-    private val buildContext: BuildContext,
+    buildContext: BuildContext,
     httpService: HttpService
 ) {
-    val instanceAttestationHelper = InstanceAttestationHelper(config.walletProviderHost, httpService)
-    val unitAttestationHelper = UnitAttestationHelper(config.walletProviderHost, httpService, keyMaterial)
-    var bufferedInstanceAttestation = MutableStateFlow<JwsSigned<JsonWebToken>?>(null)
-    var bufferedUnitAttestation = MutableStateFlow<JwsSigned<KeyAttestationJwt>?>(null)
+    val httpClient = httpService.buildHttpClient()
 
-    private val scope = CoroutineScope(Dispatchers.IO)
-
-    suspend fun preloadAttestation() = catching {
-        Napier.d("AttestationService: Preload attestation")
-        requestInstanceAttestation().let {
-            bufferedInstanceAttestation.emit(it)
-        }
-        requestUnitAttestation().let {
-            bufferedUnitAttestation.emit(it)
+    val challengeEndpoint = config.walletProviderHost.map {
+        URLBuilder(it).apply {
+            appendEncodedPathSegments(PATH_NONCE)
         }
     }
 
-    suspend fun loadInstanceAttestation() = catching {
-        requestInstanceAttestation().let { instanceAttestation ->
+    val instanceAttestationHelper = InstanceAttestationHelper(
+        config.walletProviderHost,
+        httpClient,
+        buildContext
+    )
+    
+    val keyAttestationHelper = KeyAttestationHelper(config.walletProviderHost, httpClient, holderKey)
+    val bufferedInstanceAttestation = MutableStateFlow<JwsSigned<JsonWebToken>?>(null)
+    val bufferedKeyAttestation = MutableStateFlow<JwsSigned<KeyAttestationJwt>?>(null)
+
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    suspend fun preloadInstanceAttestation() = catching {
+        Napier.d("AttestationService: Preload instance attestation")
+        requestInstanceAttestation().let {
+            bufferedInstanceAttestation.emit(it)
+        }
+    }.onFailure {
+        Napier.e("AttestationService: Error preloading instance attestation. $it")
+    }
+    suspend fun preloadKeyAttestation() = catching {
+        Napier.d("AttestationService: Preload key attestation")
+        requestKeyAttestation(
+            KeyAttestationInput(
+                clientNonce = null,
+                credentialIssuer = null,
+                supportedAlgorithms = null,
+                preferredKeyStorageStatusPeriod = PREFERRED_DEFAULT_TTL,
+            )
+        ).let {
+            bufferedKeyAttestation.emit(it)
+        }
+    }.onFailure {
+        Napier.e("AttestationService: Error preloading key attestation. $it")
+    }
+
+    suspend fun loadInstanceAttestation(input: LoadInstanceAttestationInput) = catching {
+        requestInstanceAttestation(input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL).let { instanceAttestation ->
             bufferedInstanceAttestation.emit(null)
             instanceAttestation
         }
     }
 
-
-    suspend fun loadInstanceAttestationPop(nonce: String? = null) = catching {
-        instanceAttestationHelper.buildProofOfPossession(nonce)
-    }
-
     suspend fun loadKeyAttestation(input: KeyAttestationInput) = catching {
-        requestUnitAttestation(input).also {
-            bufferedUnitAttestation.emit(null)
+        requestKeyAttestation(input).also { keyAttestation ->
+            bufferedKeyAttestation.emit(keyAttestation)
         }
     }
-
 
     fun getWalletProviderHost() = config.walletProviderHost
     fun setWalletProviderHost(host: String) = scope.launch {
         config.set(walletProviderHost = host)
-        bufferedUnitAttestation.emit(null)
+        bufferedKeyAttestation.emit(null)
         bufferedInstanceAttestation.emit(null)
     }
 
-    private suspend fun requestInstanceAttestation(): JwsSigned<JsonWebToken> {
+    private suspend fun requestInstanceAttestation(
+        preferredClientStatusPeriod: Duration = PREFERRED_DEFAULT_TTL
+    ): JwsSigned<JsonWebToken> {
         bufferedInstanceAttestation.firstOrNull()?.let { buffer ->
-            if ((buffer.payload.expiration)?.let { it > Clock.System.now() + 10.seconds } == true) {
+            if (buffer.hasRemainingClientStatusPeriod(preferredClientStatusPeriod)) {
                 Napier.d("AttestationService: Use buffered instance attestation")
                 return buffer
             }
         }
 
         Napier.d("AttestationService: Request new instance attestation")
-        val instanceAttestation = instanceAttestationHelper.requestInstanceAttestation(buildContext.versionName)
+        val instanceAttestation = instanceAttestationHelper.requestInstanceAttestation(preferredClientStatusPeriod)
         bufferedInstanceAttestation.emit(instanceAttestation)
         return instanceAttestation
     }
 
-    private suspend fun requestUnitAttestation(
-        input: KeyAttestationInput = KeyAttestationInput(
-            credentialIssuer = null,
-            clientNonce = null,
-            supportedAlgorithms = null,
-            preferredKeyStorageStatusPeriod = 31.days,
-        ),
+    private suspend fun requestKeyAttestation(
+        input: KeyAttestationInput,
     ): JwsSigned<KeyAttestationJwt> {
-        val preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod ?: 31.days
+        val preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod ?: PREFERRED_DEFAULT_TTL
 
-        bufferedUnitAttestation.firstOrNull()?.let { buffer ->
+        bufferedKeyAttestation.firstOrNull()?.let { buffer ->
             if (buffer.hasRemainingKeyStorageStatusPeriod(preferredKeyStorageStatusPeriod)) {
-                Napier.d("AttestationService: Use buffered unit attestation")
-                bufferedUnitAttestation.emit(null)
+                Napier.d("AttestationService: Use buffered key attestation")
+                bufferedKeyAttestation.emit(null)
                 return buffer
             }
         }
 
-        Napier.d("AttestationService: Request new unit attestation")
+        Napier.d("AttestationService: Request new key attestation")
 
         val instanceAttestation = requestInstanceAttestation()
-        val pop = instanceAttestationHelper.buildProofOfPossession()
 
-        return unitAttestationHelper.requestUnitAttestation(instanceAttestation, pop, input)
+        val pop = instanceAttestationHelper.buildProofOfPossession(
+            audience = config.walletProviderHost.first(),
+            nonce = getChallenge()
+        )
+
+        return keyAttestationHelper.requestKeyAttestation(
+            instanceAttestation = instanceAttestation,
+            pop = pop,
+            nonce = input.clientNonce,
+            preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod,
+            supportedAlgorithms = input.supportedAlgorithms
+        )
     }
 
     private fun JwsSigned<KeyAttestationJwt>.hasRemainingKeyStorageStatusPeriod(ttl: Duration): Boolean {
@@ -118,10 +151,18 @@ class AttestationService(
         return payload.expiration?.let { it > now + 10.seconds } == true &&
                 payload.keyStorageStatus?.expiration?.let { it > now + ttl } == true
     }
-}
 
-class HolderKeyMaterial(
-    signer: Signer,
-) : SignerBasedKeyMaterial(signer) {
-    override suspend fun getCertificate(): X509Certificate? = null
+    private fun JwsSigned<JsonWebToken>.hasRemainingClientStatusPeriod(ttl: Duration): Boolean {
+        val now = Clock.System.now()
+        return payload.expiration?.let { it > now + 10.seconds } == true &&
+                payload.clientStatus?.expiration?.let { it > now + ttl } == true
+    }
+
+    private suspend fun getChallenge() = catching {
+        httpClient.get(challengeEndpoint.first().build()) {
+        }.body<ClientNonceResponse>().clientNonce
+    }.onFailure {
+        Napier.e("AttestationService: Error receiving challenge. $it")
+    }.getOrNull()
+
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -38,27 +38,33 @@ class AttestationService(
     private val scope = CoroutineScope(Dispatchers.IO)
     private val httpClient = httpService.buildHttpClient()
 
-    private val challengeEndpoint = config.walletProviderHost.map {
+    private fun challengeEndpoint() = config.walletProviderHost.map {
         URLBuilder(it).apply {
             appendEncodedPathSegments(PATH_NONCE)
         }
     }
 
     private val instanceAttestationHelper = InstanceAttestationHelper(
-        config.walletProviderHost,
+        config,
         httpClient,
         buildContext,
     )
 
-    private val keyAttestationHelper = KeyAttestationHelper(config.walletProviderHost, httpClient, holderKey)
+    private val keyAttestationHelper = KeyAttestationHelper(config, httpClient, holderKey)
     val bufferedInstanceAttestation = MutableStateFlow<JwsCompactTyped<JsonWebToken>?>(null)
     val bufferedKeyAttestation = MutableStateFlow<JwsCompactTyped<KeyAttestationJwt>?>(null)
+
+    suspend fun reset() {
+        bufferedKeyAttestation.emit(null)
+        bufferedInstanceAttestation.emit(null)
+        instanceAttestationHelper.reset()
+    }
 
     suspend fun getInstanceAttestationKeyMaterial() = instanceAttestationHelper.keyMaterial()
 
     suspend fun preloadInstanceAttestation() = catchingUnwrapped {
         Napier.d("AttestationService: Preload instance attestation")
-        requestInstanceAttestation().let {
+        requestInstanceAttestation(preloadInstanceAttestationInput).let {
             bufferedInstanceAttestation.emit(it)
         }
     }.onFailure {
@@ -67,14 +73,7 @@ class AttestationService(
 
     suspend fun preloadKeyAttestation() = catchingUnwrapped {
         Napier.d("AttestationService: Preload key attestation")
-        requestKeyAttestation(
-            KeyAttestationInput(
-                clientNonce = null,
-                credentialIssuer = null,
-                supportedAlgorithms = null,
-                preferredKeyStorageStatusPeriod = PREFERRED_DEFAULT_TTL,
-            )
-        ).let {
+        requestKeyAttestation(preloadKeyAttestationInput).let {
             bufferedKeyAttestation.emit(it)
         }
     }.onFailure {
@@ -82,57 +81,57 @@ class AttestationService(
     }
 
     suspend fun loadInstanceAttestation(input: LoadInstanceAttestationInput) = catching {
-        requestInstanceAttestation(
-            input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL
-        )
+        requestInstanceAttestation(input)
     }
 
     suspend fun loadKeyAttestation(input: KeyAttestationInput) = catching {
-        if (!input.allowBuffer()) bufferedKeyAttestation.emit(null)
-        requestKeyAttestation(input).also { keyAttestation ->
-            bufferedKeyAttestation.emit(keyAttestation)
-        }
+        requestKeyAttestation(input)
     }
 
     fun getWalletProviderHost() = config.walletProviderHost
     fun setWalletProviderHost(host: String) = scope.launch {
         config.set(walletProviderHost = host)
-        bufferedKeyAttestation.emit(null)
-        bufferedInstanceAttestation.emit(null)
+        reset()
     }
 
     private suspend fun requestInstanceAttestation(
-        preferredClientStatusPeriod: Duration = PREFERRED_DEFAULT_TTL
+        input: LoadInstanceAttestationInput,
     ): JwsCompactTyped<JsonWebToken> {
-        bufferedInstanceAttestation.firstOrNull()?.let { buffer ->
-            if (buffer.hasRemainingClientStatusPeriod(preferredClientStatusPeriod)) {
-                Napier.d("AttestationService: Use buffered instance attestation")
-                return buffer
+        if (input.allowBuffer()) {
+            bufferedInstanceAttestation.firstOrNull()?.let { buffer ->
+                if (buffer.hasRemainingClientStatusPeriod(input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL)) {
+                    Napier.d("AttestationService: Use buffered instance attestation")
+                    return buffer
+                }
             }
         }
 
+
         Napier.d("AttestationService: Request new instance attestation")
-        val instanceAttestation = instanceAttestationHelper.instanceAttestation(preferredClientStatusPeriod)
-        bufferedInstanceAttestation.emit(instanceAttestation)
-        return instanceAttestation
+        return instanceAttestationHelper.instanceAttestation(input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL)
+            .also {
+                if (input.allowBuffer()) {
+                    bufferedInstanceAttestation.emit(it)
+                }
+            }
     }
 
     private suspend fun requestKeyAttestation(
         input: KeyAttestationInput,
     ): JwsCompactTyped<KeyAttestationJwt> {
-        val preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod ?: PREFERRED_DEFAULT_TTL
-
-        bufferedKeyAttestation.firstOrNull()?.let { buffer ->
-            if (buffer.hasRemainingKeyStorageStatusPeriod(preferredKeyStorageStatusPeriod)) {
-                Napier.d("AttestationService: Use buffered key attestation")
-                bufferedKeyAttestation.emit(null)
-                return buffer
+        if (input.allowBuffer()) {
+            bufferedKeyAttestation.firstOrNull()?.let { buffer ->
+                if (buffer.hasRemainingKeyStorageStatusPeriod(input.preferredKeyStorageStatusPeriod ?: PREFERRED_DEFAULT_TTL)) {
+                    Napier.d("AttestationService: Use buffered key attestation")
+                    bufferedKeyAttestation.emit(null)
+                    return buffer
+                }
             }
         }
 
         Napier.d("AttestationService: Request new key attestation")
 
-        val instanceAttestation = requestInstanceAttestation()
+        val instanceAttestation = requestInstanceAttestation(preloadInstanceAttestationInput)
 
         val pop = instanceAttestationHelper.buildProofOfPossession(
             audience = config.walletProviderHost.first(), nonce = getChallenge()
@@ -144,7 +143,11 @@ class AttestationService(
             nonce = input.clientNonce,
             preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod,
             supportedAlgorithms = input.supportedAlgorithms
-        )
+        ).also {
+            if (input.allowBuffer()) {
+                bufferedKeyAttestation.emit(it)
+            }
+        }
     }
 
     private fun JwsCompactTyped<KeyAttestationJwt>.hasRemainingKeyStorageStatusPeriod(ttl: Duration): Boolean {
@@ -158,7 +161,7 @@ class AttestationService(
     }
 
     private suspend fun getChallenge() = catchingUnwrapped {
-        httpClient.get(challengeEndpoint.first().build()) {}.body<ClientNonceResponse>().clientNonce
+        httpClient.get(challengeEndpoint().first().build()) {}.body<ClientNonceResponse>().clientNonce
     }.onFailure {
         Napier.e("AttestationService: Error receiving challenge. $it")
     }.getOrNull()
@@ -166,3 +169,7 @@ class AttestationService(
 }
 
 fun KeyAttestationInput.allowBuffer() = (this.credentialIssuer == null && this.clientNonce == null)
+fun LoadInstanceAttestationInput.allowBuffer() = false
+
+val preloadInstanceAttestationInput = LoadInstanceAttestationInput("", PREFERRED_DEFAULT_TTL)
+val preloadKeyAttestationInput = KeyAttestationInput(null, null, null, PREFERRED_DEFAULT_TTL)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/AttestationService.kt
@@ -1,7 +1,6 @@
 package at.asitplus.wallet.app.common.attestation
 
-import at.asitplus.KmmResult
-import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.ClientNonceResponse
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
@@ -56,7 +55,7 @@ class AttestationService(
 
     suspend fun getInstanceAttestationKeyMaterial() = instanceAttestationHelper.keyMaterial()
 
-    suspend fun preloadInstanceAttestation() = runCatching {
+    suspend fun preloadInstanceAttestation() = catchingUnwrapped {
         Napier.d("AttestationService: Preload instance attestation")
         requestInstanceAttestation().let {
             bufferedInstanceAttestation.emit(it)
@@ -65,7 +64,7 @@ class AttestationService(
         Napier.e("AttestationService: Error preloading instance attestation. $it")
     }
 
-    suspend fun preloadKeyAttestation() = runCatching {
+    suspend fun preloadKeyAttestation() = catchingUnwrapped {
         Napier.d("AttestationService: Preload key attestation")
         requestKeyAttestation(
             KeyAttestationInput(
@@ -81,14 +80,14 @@ class AttestationService(
         Napier.e("AttestationService: Error preloading key attestation. $it")
     }
 
-    suspend fun loadInstanceAttestation(input: LoadInstanceAttestationInput) = catching {
+    suspend fun loadInstanceAttestation(input: LoadInstanceAttestationInput) = catchingUnwrapped {
         requestInstanceAttestation(
             input.preferredClientStatusPeriod ?: PREFERRED_DEFAULT_TTL
         )
     }
 
-    suspend fun loadKeyAttestation(input: KeyAttestationInput): KmmResult<JwsCompactTyped<KeyAttestationJwt>> =
-        catching {
+    suspend fun loadKeyAttestation(input: KeyAttestationInput): Result<JwsCompactTyped<KeyAttestationJwt>> =
+        catchingUnwrapped {
             if (!input.allowBuffer()) bufferedKeyAttestation.emit(null)
             requestKeyAttestation(input).also { keyAttestation ->
                 bufferedKeyAttestation.emit(keyAttestation)
@@ -161,7 +160,7 @@ class AttestationService(
                 payload.clientStatus?.expiration?.let { it > now + ttl } == true
     }
 
-    private suspend fun getChallenge() = runCatching {
+    private suspend fun getChallenge() = catchingUnwrapped {
         httpClient.get(challengeEndpoint.first().build()) {
         }.body<ClientNonceResponse>().clientNonce
     }.onFailure {

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/Constants.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/Constants.kt
@@ -1,0 +1,9 @@
+package at.asitplus.wallet.app.common.attestation
+
+const val KS_ALIAS_WIA = "ALIAS_WIA"
+const val LOCAL_NATIVE = "LOCAL_NATIVE"
+const val WALLET_SOLUTION_OID = "2.25.210184084534939142470042512176304499012"
+const val PATH_CHALLENGE = "api/v1/challenge"
+const val PATH_INSTANCE = "api/v1/instance"
+const val PATH_UNIT = "api/v1/unit"
+const val PATH_NONCE = "api/v1/nonce"

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/Constants.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/Constants.kt
@@ -1,7 +1,6 @@
 package at.asitplus.wallet.app.common.attestation
 
 const val KS_ALIAS_WIA = "ALIAS_WIA"
-const val LOCAL_NATIVE = "LOCAL_NATIVE"
 const val WALLET_SOLUTION_OID = "2.25.210184084534939142470042512176304499012"
 const val PATH_CHALLENGE = "api/v1/challenge"
 const val PATH_INSTANCE = "api/v1/instance"

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/Constants.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/Constants.kt
@@ -1,8 +1,11 @@
 package at.asitplus.wallet.app.common.attestation
 
+import kotlin.time.Duration.Companion.days
+
 const val KS_ALIAS_WIA = "ALIAS_WIA"
 const val WALLET_SOLUTION_OID = "2.25.210184084534939142470042512176304499012"
 const val PATH_CHALLENGE = "api/v1/challenge"
-const val PATH_INSTANCE = "api/v1/instance"
-const val PATH_UNIT = "api/v1/unit"
+const val PATH_INSTANCE = "api/v1/instanceAttestation"
+const val PATH_UNIT = "api/v1/keyAttestation"
 const val PATH_NONCE = "api/v1/nonce"
+val PREFERRED_DEFAULT_TTL = 31.days

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
@@ -1,0 +1,124 @@
+package at.asitplus.wallet.app.common.attestation
+
+import at.asitplus.attestation.supreme.AttestationChallenge
+import at.asitplus.attestation.supreme.AttestationClient
+import at.asitplus.attestation.supreme.createCsr
+import at.asitplus.openid.ClientNonceResponse
+import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import at.asitplus.signum.indispensable.asn1.encoding.encodeToAsn1Primitive
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequestAttribute
+import at.asitplus.signum.supreme.os.PlatformSigningProvider
+import at.asitplus.wallet.app.common.HttpService
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
+import at.asitplus.wallet.lib.jws.SignJwtFun
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.appendEncodedPathSegments
+import io.ktor.http.contentType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+
+class InstanceAttestationHelper(val host: Flow<String>, httpService: HttpService) {
+    val challengeEndpoint = host.map {
+        URLBuilder(host.first()).apply {
+            appendEncodedPathSegments(PATH_CHALLENGE)
+        }
+    }
+    val instanceEndpoint = host.map {
+        URLBuilder(host.first()).apply {
+            appendEncodedPathSegments(PATH_INSTANCE)
+        }
+    }
+    val nonceEndpoint = host.map {
+        URLBuilder(host.first()).apply {
+            appendEncodedPathSegments(PATH_NONCE)
+        }
+    }
+    val httpClient = httpService.buildHttpClient()
+    val client = AttestationClient(httpClient)
+
+    suspend fun createAttestationSigner(challenge: AttestationChallenge, alias: String) =
+        PlatformSigningProvider.createSigningKey(alias) {
+            ec {}
+            hardware {
+                attestation {
+                    this.challenge = challenge.nonce
+                }
+            }
+        }.getOrThrow()
+
+    private suspend fun getAttestationChallenge() = client.getChallenge(Url(challengeEndpoint.first()))
+    private suspend fun getNonce() = runCatching {
+        httpClient.get(Url(nonceEndpoint.first())) {
+        }.body<ClientNonceResponse>().clientNonce
+    }
+
+
+    suspend fun requestInstanceAttestation(versionName: String) =
+        getAttestationChallenge().getOrThrow().let { challenge ->
+            PlatformSigningProvider.deleteSigningKey(KS_ALIAS_WIA)
+            val instanceAttestationSigner = createAttestationSigner(challenge, KS_ALIAS_WIA)
+            val csr = instanceAttestationSigner.createCsr(
+                challenge = challenge, additionalAttributes = listOf(
+                    Pkcs10CertificationRequestAttribute(
+                        oid = ObjectIdentifier(oid = WALLET_SOLUTION_OID), listOf(
+                            versionName.encodeToAsn1Primitive()
+                        )
+                    )
+                )
+            ).getOrThrow()
+            val response = httpClient.post(Url(instanceEndpoint.first())) {
+                contentType(ContentType.Application.OctetStream)
+                setBody(csr.encodeToDer())
+            }
+            JwsSigned.deserialize<JsonWebToken>(
+                it = response.bodyAsText(),
+                deserializationStrategy = JsonWebToken.serializer(),
+            ).getOrThrow()
+        }
+
+    suspend fun buildProofOfPossession(nonce: String? = null): JwsSigned<JsonWebToken> =
+        PlatformSigningProvider.getSignerForKey(KS_ALIAS_WIA).getOrThrow().let {
+            BuildInstanceAttestationProofJwt(
+                SignJwt(HolderKeyMaterial(it), headerModifier = JwsHeaderNone()),
+                lifetime = 1.minutes,
+                audience = null,
+                nonce = nonce ?: getNonce().getOrNull()
+            )
+        }
+}
+
+object BuildInstanceAttestationProofJwt {
+    @OptIn(ExperimentalTime::class)
+    suspend operator fun invoke(
+        signJwt: SignJwtFun<JsonWebToken>,
+        audience: String? = null,
+        nonce: String? = null,
+        lifetime: Duration = 60.minutes,
+        clockSkew: Duration = 5.minutes,
+    ) = signJwt(
+        CLIENT_ATTESTATION_POP_JWT,
+        JsonWebToken(
+            audience = audience,
+            nonce = nonce,
+            issuedAt = Clock.System.now() - clockSkew,
+            expiration = Clock.System.now() + lifetime
+        ),
+        JsonWebToken.Companion.serializer(),
+    ).getOrThrow()
+}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
@@ -2,7 +2,7 @@ package at.asitplus.wallet.app.common.attestation
 
 import at.asitplus.attestation.supreme.AttestationClient
 import at.asitplus.attestation.supreme.createAttestationProof
-import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.asn1.encoding.encodeToAsn1Primitive
 import at.asitplus.signum.indispensable.josef.JsonWebToken
@@ -98,7 +98,9 @@ class InstanceAttestationHelper(
             keyMaterialCache = it
         }
 
-        val attestation = catching { JwsCompactTyped<JsonWebToken>(response.bodyAsText()) }.getOrThrow().also {
+        val attestation = catchingUnwrapped {
+            JwsCompactTyped<JsonWebToken>(response.bodyAsText())
+        }.getOrThrow().also {
             instanceAttestationCache = it
         }
         Pair(attestation, keyMaterial)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
@@ -12,6 +12,7 @@ import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequestAttribute
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.signum.supreme.os.PlatformSigningProvider
 import at.asitplus.wallet.app.common.BuildContext
+import at.asitplus.wallet.app.common.data.SettingsRepository
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.SignerBasedKeyMaterial
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
@@ -34,19 +35,24 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 class InstanceAttestationHelper(
-    private val host: Flow<String>,
+    private val config: SettingsRepository,
     private val httpClient: HttpClient,
     private val buildContext: BuildContext,
 ) {
-    private val challengeEndpoint = host.map {
-        URLBuilder(host.first()).apply {
+    private fun challengeEndpoint() = config.walletProviderHost.map {
+        URLBuilder(it).apply {
             appendEncodedPathSegments(PATH_CHALLENGE)
         }
     }
-    private val instanceEndpoint = host.map {
-        URLBuilder(host.first()).apply {
+    private fun instanceEndpoint() = config.walletProviderHost.map {
+        URLBuilder(it).apply {
             appendEncodedPathSegments(PATH_INSTANCE)
         }
+    }
+
+    suspend fun reset() {
+        instanceAttestationCache = null
+        keyMaterialCache = null
     }
 
     private val client = AttestationClient(httpClient)
@@ -66,7 +72,7 @@ class InstanceAttestationHelper(
         }
     }
 
-    private suspend fun getAttestationChallenge() = client.getChallenge(Url(challengeEndpoint.first()))
+    private suspend fun getAttestationChallenge() = client.getChallenge(Url(challengeEndpoint().first()))
 
     private suspend fun getAttestationProof(preferredClientStatusPeriod: Duration) =
         getAttestationChallenge().getOrThrow().let { challenge ->
@@ -89,7 +95,7 @@ class InstanceAttestationHelper(
     private suspend fun getInstanceAttestation(
         preferredClientStatusPeriod: Duration
     ) = getAttestationProof(preferredClientStatusPeriod).let { proof ->
-        val response = httpClient.post(Url(instanceEndpoint.first())) {
+        val response = httpClient.post(Url(instanceEndpoint().first())) {
             contentType(ContentType.Application.OctetStream)
             setBody(proof.encodeToDer())
         }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
@@ -3,20 +3,21 @@ package at.asitplus.wallet.app.common.attestation
 import at.asitplus.attestation.supreme.AttestationChallenge
 import at.asitplus.attestation.supreme.AttestationClient
 import at.asitplus.attestation.supreme.createCsr
-import at.asitplus.openid.ClientNonceResponse
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.asn1.encoding.encodeToAsn1Primitive
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequestAttribute
+import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.signum.supreme.os.PlatformSigningProvider
-import at.asitplus.wallet.app.common.HttpService
-import at.asitplus.wallet.lib.jws.JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT
+import at.asitplus.wallet.app.common.BuildContext
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.agent.SignerBasedKeyMaterial
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
-import at.asitplus.wallet.lib.jws.SignJwtFun
-import io.ktor.client.call.body
-import io.ktor.client.request.get
+import at.asitplus.wallet.lib.oidvci.BuildClientAttestationPoPJwt
+import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -28,12 +29,16 @@ import io.ktor.http.contentType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlin.time.Clock
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.ExperimentalTime
 
-class InstanceAttestationHelper(val host: Flow<String>, httpService: HttpService) {
+class InstanceAttestationHelper(
+    val host: Flow<String>,
+    val httpClient: HttpClient,
+    val buildContext: BuildContext,
+) {
     val challengeEndpoint = host.map {
         URLBuilder(host.first()).apply {
             appendEncodedPathSegments(PATH_CHALLENGE)
@@ -44,13 +49,24 @@ class InstanceAttestationHelper(val host: Flow<String>, httpService: HttpService
             appendEncodedPathSegments(PATH_INSTANCE)
         }
     }
-    val nonceEndpoint = host.map {
-        URLBuilder(host.first()).apply {
-            appendEncodedPathSegments(PATH_NONCE)
+
+    val client = AttestationClient(httpClient)
+
+    val challenge by lazy { runBlocking { getAttestationChallenge().getOrThrow() }
+    }
+
+    val instanceAttestationSigner by lazy {
+        runBlocking {
+            PlatformSigningProvider.deleteSigningKey(KS_ALIAS_WIA)
+            val alias = KS_ALIAS_WIA
+            createAttestationSigner(challenge, alias)
         }
     }
-    val httpClient = httpService.buildHttpClient()
-    val client = AttestationClient(httpClient)
+
+
+    fun instanceAttestationKeyMaterial() = object : SignerBasedKeyMaterial(instanceAttestationSigner) {
+        override suspend fun getCertificate(): X509Certificate? = null
+    }
 
     suspend fun createAttestationSigner(challenge: AttestationChallenge, alias: String) =
         PlatformSigningProvider.createSigningKey(alias) {
@@ -63,21 +79,21 @@ class InstanceAttestationHelper(val host: Flow<String>, httpService: HttpService
         }.getOrThrow()
 
     private suspend fun getAttestationChallenge() = client.getChallenge(Url(challengeEndpoint.first()))
-    private suspend fun getNonce() = runCatching {
-        httpClient.get(Url(nonceEndpoint.first())) {
-        }.body<ClientNonceResponse>().clientNonce
-    }
 
-
-    suspend fun requestInstanceAttestation(versionName: String) =
-        getAttestationChallenge().getOrThrow().let { challenge ->
-            PlatformSigningProvider.deleteSigningKey(KS_ALIAS_WIA)
-            val instanceAttestationSigner = createAttestationSigner(challenge, KS_ALIAS_WIA)
+    suspend fun requestInstanceAttestation(
+        preferredClientStatusPeriod: Duration
+    ) =
+        challenge.let { challenge ->
             val csr = instanceAttestationSigner.createCsr(
                 challenge = challenge, additionalAttributes = listOf(
                     Pkcs10CertificationRequestAttribute(
                         oid = ObjectIdentifier(oid = WALLET_SOLUTION_OID), listOf(
-                            versionName.encodeToAsn1Primitive()
+                            joseCompliantSerializer.encodeToString(
+                                InstanceAttestationRequest(
+                                    buildContext.versionName,
+                                    preferredClientStatusPeriod
+                                )
+                            ).encodeToAsn1Primitive(),
                         )
                     )
                 )
@@ -92,33 +108,21 @@ class InstanceAttestationHelper(val host: Flow<String>, httpService: HttpService
             ).getOrThrow()
         }
 
-    suspend fun buildProofOfPossession(nonce: String? = null): JwsSigned<JsonWebToken> =
-        PlatformSigningProvider.getSignerForKey(KS_ALIAS_WIA).getOrThrow().let {
-            BuildInstanceAttestationProofJwt(
-                SignJwt(HolderKeyMaterial(it), headerModifier = JwsHeaderNone()),
-                lifetime = 1.minutes,
-                audience = null,
-                nonce = nonce ?: getNonce().getOrNull()
-            )
-        }
+    suspend fun buildProofOfPossession(
+        audience: String,
+        nonce: String?,
+    ): JwsSigned<JsonWebToken> =
+        BuildClientAttestationPoPJwt.invoke(
+            clientId = buildContext.versionName,
+            signJwt = SignJwt(instanceAttestationKeyMaterial(), headerModifier = JwsHeaderNone()),
+            lifetime = 1.minutes,
+            audience = audience,
+            nonce = nonce
+        )
 }
 
-object BuildInstanceAttestationProofJwt {
-    @OptIn(ExperimentalTime::class)
-    suspend operator fun invoke(
-        signJwt: SignJwtFun<JsonWebToken>,
-        audience: String? = null,
-        nonce: String? = null,
-        lifetime: Duration = 60.minutes,
-        clockSkew: Duration = 5.minutes,
-    ) = signJwt(
-        CLIENT_ATTESTATION_POP_JWT,
-        JsonWebToken(
-            audience = audience,
-            nonce = nonce,
-            issuedAt = Clock.System.now() - clockSkew,
-            expiration = Clock.System.now() + lifetime
-        ),
-        JsonWebToken.Companion.serializer(),
-    ).getOrThrow()
-}
+@Serializable
+data class InstanceAttestationRequest(
+    val versionName: String,
+    val preferredClientStatusPeriod: Duration? = null
+)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/InstanceAttestationHelper.kt
@@ -1,12 +1,12 @@
 package at.asitplus.wallet.app.common.attestation
 
-import at.asitplus.attestation.supreme.AttestationChallenge
 import at.asitplus.attestation.supreme.AttestationClient
-import at.asitplus.attestation.supreme.createCsr
+import at.asitplus.attestation.supreme.createAttestationProof
+import at.asitplus.catching
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.asn1.encoding.encodeToAsn1Primitive
 import at.asitplus.signum.indispensable.josef.JsonWebToken
-import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.Pkcs10CertificationRequestAttribute
 import at.asitplus.signum.indispensable.pki.X509Certificate
@@ -29,100 +29,101 @@ import io.ktor.http.contentType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 class InstanceAttestationHelper(
-    val host: Flow<String>,
-    val httpClient: HttpClient,
-    val buildContext: BuildContext,
+    private val host: Flow<String>,
+    private val httpClient: HttpClient,
+    private val buildContext: BuildContext,
 ) {
-    val challengeEndpoint = host.map {
+    private val challengeEndpoint = host.map {
         URLBuilder(host.first()).apply {
             appendEncodedPathSegments(PATH_CHALLENGE)
         }
     }
-    val instanceEndpoint = host.map {
+    private val instanceEndpoint = host.map {
         URLBuilder(host.first()).apply {
             appendEncodedPathSegments(PATH_INSTANCE)
         }
     }
 
-    val client = AttestationClient(httpClient)
+    private val client = AttestationClient(httpClient)
 
-    val challenge by lazy { runBlocking { getAttestationChallenge().getOrThrow() }
+    private var instanceAttestationCache: JwsCompactTyped<JsonWebToken>? = null
+    private var keyMaterialCache: KeyMaterial? = null
+
+    suspend fun instanceAttestation(
+        preferredClientStatusPeriod: Duration
+    ) = instanceAttestationCache ?: getInstanceAttestation(preferredClientStatusPeriod).let { (attestation, _) ->
+        attestation
     }
 
-    val instanceAttestationSigner by lazy {
-        runBlocking {
-            PlatformSigningProvider.deleteSigningKey(KS_ALIAS_WIA)
-            val alias = KS_ALIAS_WIA
-            createAttestationSigner(challenge, alias)
+    suspend fun keyMaterial() = keyMaterialCache ?: run {
+        getInstanceAttestation(PREFERRED_DEFAULT_TTL).let { (_, keyMaterial) ->
+            keyMaterial
         }
     }
 
-
-    fun instanceAttestationKeyMaterial() = object : SignerBasedKeyMaterial(instanceAttestationSigner) {
-        override suspend fun getCertificate(): X509Certificate? = null
-    }
-
-    suspend fun createAttestationSigner(challenge: AttestationChallenge, alias: String) =
-        PlatformSigningProvider.createSigningKey(alias) {
-            ec {}
-            hardware {
-                attestation {
-                    this.challenge = challenge.nonce
-                }
-            }
-        }.getOrThrow()
-
     private suspend fun getAttestationChallenge() = client.getChallenge(Url(challengeEndpoint.first()))
 
-    suspend fun requestInstanceAttestation(
-        preferredClientStatusPeriod: Duration
-    ) =
-        challenge.let { challenge ->
-            val csr = instanceAttestationSigner.createCsr(
-                challenge = challenge, additionalAttributes = listOf(
+    private suspend fun getAttestationProof(preferredClientStatusPeriod: Duration) =
+        getAttestationChallenge().getOrThrow().let { challenge ->
+            PlatformSigningProvider.deleteSigningKey(alias = KS_ALIAS_WIA)
+            challenge.createAttestationProof(
+                alias = KS_ALIAS_WIA, additionalCsrAttributes = listOf(
                     Pkcs10CertificationRequestAttribute(
                         oid = ObjectIdentifier(oid = WALLET_SOLUTION_OID), listOf(
                             joseCompliantSerializer.encodeToString(
                                 InstanceAttestationRequest(
-                                    buildContext.versionName,
-                                    preferredClientStatusPeriod
+                                    buildContext.versionName, preferredClientStatusPeriod
                                 )
                             ).encodeToAsn1Primitive(),
                         )
                     )
                 )
             ).getOrThrow()
-            val response = httpClient.post(Url(instanceEndpoint.first())) {
-                contentType(ContentType.Application.OctetStream)
-                setBody(csr.encodeToDer())
+        }
+
+    private suspend fun getInstanceAttestation(
+        preferredClientStatusPeriod: Duration
+    ) = getAttestationProof(preferredClientStatusPeriod).let { proof ->
+        val response = httpClient.post(Url(instanceEndpoint.first())) {
+            contentType(ContentType.Application.OctetStream)
+            setBody(proof.encodeToDer())
+        }
+
+        val keyMaterial = signerBasedKeyMaterial().also {
+            keyMaterialCache = it
+        }
+
+        val attestation = catching { JwsCompactTyped<JsonWebToken>(response.bodyAsText()) }.getOrThrow().also {
+            instanceAttestationCache = it
+        }
+        Pair(attestation, keyMaterial)
+    }
+
+    private suspend fun signerBasedKeyMaterial() =
+        PlatformSigningProvider.getSignerForKey(KS_ALIAS_WIA).getOrThrow().let {
+            object : SignerBasedKeyMaterial(it) {
+                override suspend fun getCertificate(): X509Certificate? = null
             }
-            JwsSigned.deserialize<JsonWebToken>(
-                it = response.bodyAsText(),
-                deserializationStrategy = JsonWebToken.serializer(),
-            ).getOrThrow()
         }
 
     suspend fun buildProofOfPossession(
         audience: String,
         nonce: String?,
-    ): JwsSigned<JsonWebToken> =
-        BuildClientAttestationPoPJwt.invoke(
-            clientId = buildContext.versionName,
-            signJwt = SignJwt(instanceAttestationKeyMaterial(), headerModifier = JwsHeaderNone()),
-            lifetime = 1.minutes,
-            audience = audience,
-            nonce = nonce
-        )
+    ): JwsCompactTyped<JsonWebToken> = BuildClientAttestationPoPJwt.invoke(
+        clientId = buildContext.versionName,
+        signJwt = SignJwt(keyMaterial(), headerModifier = JwsHeaderNone()),
+        lifetime = 1.minutes,
+        audience = audience,
+        nonce = nonce
+    )
 }
 
 @Serializable
-data class InstanceAttestationRequest(
-    val versionName: String,
-    val preferredClientStatusPeriod: Duration? = null
+private data class InstanceAttestationRequest(
+    val versionName: String, val preferredClientStatusPeriod: Duration? = null
 )

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
@@ -1,6 +1,6 @@
 package at.asitplus.wallet.app.common.attestation
 
-import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.DurationSecondsIntSerializer
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebToken
@@ -61,7 +61,7 @@ class KeyAttestationHelper(
             )
         }
 
-        return catching { JwsCompactTyped<KeyAttestationJwt>(response.bodyAsText()) }.getOrThrow()
+        return catchingUnwrapped { JwsCompactTyped<KeyAttestationJwt>(response.bodyAsText()) }.getOrThrow()
     }
 
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
@@ -8,6 +8,7 @@ import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.app.common.WalletKeyMaterial
+import at.asitplus.wallet.app.common.data.SettingsRepository
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -25,12 +26,12 @@ import kotlinx.serialization.Serializable
 import kotlin.time.Duration
 
 class KeyAttestationHelper(
-    private val host: Flow<String>,
+    private val config: SettingsRepository,
     private val httpClient: HttpClient,
     private val keyMaterial: WalletKeyMaterial,
 ) {
-    private val keyAttestationEndpoint = host.map {
-        URLBuilder(host.first()).apply {
+    private fun keyAttestationEndpoint() = config.walletProviderHost.map {
+        URLBuilder(it).apply {
             appendEncodedPathSegments(PATH_UNIT)
         }
     }
@@ -45,7 +46,7 @@ class KeyAttestationHelper(
     ): JwsCompactTyped<KeyAttestationJwt> {
         val holderKey = keyMaterial.getUnderLyingSigner()
 
-        val response = httpClient.post(Url(keyAttestationEndpoint.first())) {
+        val response = httpClient.post(Url(keyAttestationEndpoint().first())) {
             contentType(ContentType.Application.Json)
             setBody(
                 KeyAttestationRequest(

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
@@ -6,9 +6,8 @@ import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
-import at.asitplus.wallet.app.common.HttpService
 import at.asitplus.wallet.app.common.WalletKeyMaterial
-import at.asitplus.wallet.lib.oidvci.WalletService.KeyAttestationInput
+import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -22,38 +21,42 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.collections.listOf
 import kotlin.time.Duration
 
-class UnitAttestationHelper(
+class KeyAttestationHelper(
     val host: Flow<String>,
-    httpService: HttpService,
+    val httpClient: HttpClient,
     val keyMaterial: WalletKeyMaterial,
 ) {
-    val unitEndpoint = host.map {
+    val keyAttestationEndpoint = host.map {
         URLBuilder(host.first()).apply {
             appendEncodedPathSegments(PATH_UNIT)
         }
     }
-    val httpClient = httpService.buildHttpClient()
 
-    suspend fun requestUnitAttestation(
+    suspend fun requestKeyAttestation(
         instanceAttestation: JwsSigned<JsonWebToken>,
         pop: JwsSigned<JsonWebToken>,
-        input: KeyAttestationInput,
+        nonce: String?,
+        preferredKeyStorageStatusPeriod: Duration?,
+        supportedAlgorithms: Collection<String>?
+
     ): JwsSigned<KeyAttestationJwt> {
         val holderKey = keyMaterial.getUnderLyingSigner()
 
-        val response = httpClient.post(Url(unitEndpoint.first())) {
+        val response = httpClient.post(Url(keyAttestationEndpoint.first())) {
             contentType(ContentType.Application.Json)
             setBody(
-                UnitAttestationRequest(
+                KeyAttestationRequest(
                     token = instanceAttestation.serialize(),
                     keys = listOf(holderKey.publicKey.toJsonWebKey()),
                     proof = pop.serialize(),
-                    nonce = input.clientNonce,
-                    credentialIssuer = input.credentialIssuer,
-                    preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod,
-                    supportedAlgorithms = input.supportedAlgorithms,
+                    nonce = nonce,
+                    keyStorage = setOf("iso_18045_moderate"),
+                    userAuthentication = setOf("iso_18045_moderate"),
+                    preferredKeyStorageStatusPeriod = preferredKeyStorageStatusPeriod,
+                    supportedAlgorithms = supportedAlgorithms,
                 )
             )
         }
@@ -66,12 +69,13 @@ class UnitAttestationHelper(
 }
 
 @Serializable
-data class UnitAttestationRequest(
+data class KeyAttestationRequest(
     @SerialName("token") val token: String,
     @SerialName("proof") val proof: String,
     @SerialName("keys") val keys: List<JsonWebKey>,
     @SerialName("nonce") val nonce: String?,
-    @SerialName("credential_issuer") val credentialIssuer: String?,
+    @SerialName("key_storage") val keyStorage: Set<String>,
+    @SerialName("user_authentication") val userAuthentication: Set<String>,
     @SerialName("preferred_key_storage_status_period")
     @Serializable(with = DurationSecondsIntSerializer::class)
     val preferredKeyStorageStatusPeriod: Duration?,

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/KeyAttestationHelper.kt
@@ -1,9 +1,10 @@
 package at.asitplus.wallet.app.common.attestation
 
+import at.asitplus.catching
 import at.asitplus.openid.DurationSecondsIntSerializer
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebToken
-import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.app.common.WalletKeyMaterial
@@ -21,37 +22,36 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlin.collections.listOf
 import kotlin.time.Duration
 
 class KeyAttestationHelper(
-    val host: Flow<String>,
-    val httpClient: HttpClient,
-    val keyMaterial: WalletKeyMaterial,
+    private val host: Flow<String>,
+    private val httpClient: HttpClient,
+    private val keyMaterial: WalletKeyMaterial,
 ) {
-    val keyAttestationEndpoint = host.map {
+    private val keyAttestationEndpoint = host.map {
         URLBuilder(host.first()).apply {
             appendEncodedPathSegments(PATH_UNIT)
         }
     }
 
     suspend fun requestKeyAttestation(
-        instanceAttestation: JwsSigned<JsonWebToken>,
-        pop: JwsSigned<JsonWebToken>,
+        instanceAttestation: JwsCompactTyped<JsonWebToken>,
+        pop: JwsCompactTyped<JsonWebToken>,
         nonce: String?,
         preferredKeyStorageStatusPeriod: Duration?,
         supportedAlgorithms: Collection<String>?
 
-    ): JwsSigned<KeyAttestationJwt> {
+    ): JwsCompactTyped<KeyAttestationJwt> {
         val holderKey = keyMaterial.getUnderLyingSigner()
 
         val response = httpClient.post(Url(keyAttestationEndpoint.first())) {
             contentType(ContentType.Application.Json)
             setBody(
                 KeyAttestationRequest(
-                    token = instanceAttestation.serialize(),
+                    token = instanceAttestation.jws.toString(),
                     keys = listOf(holderKey.publicKey.toJsonWebKey()),
-                    proof = pop.serialize(),
+                    proof = pop.jws.toString(),
                     nonce = nonce,
                     keyStorage = setOf("iso_18045_moderate"),
                     userAuthentication = setOf("iso_18045_moderate"),
@@ -61,15 +61,13 @@ class KeyAttestationHelper(
             )
         }
 
-        return JwsSigned.deserialize<KeyAttestationJwt>(
-            it = response.bodyAsText(), deserializationStrategy = KeyAttestationJwt.serializer()
-        ).getOrThrow()
+        return catching { JwsCompactTyped<KeyAttestationJwt>(response.bodyAsText()) }.getOrThrow()
     }
 
 }
 
 @Serializable
-data class KeyAttestationRequest(
+private data class KeyAttestationRequest(
     @SerialName("token") val token: String,
     @SerialName("proof") val proof: String,
     @SerialName("keys") val keys: List<JsonWebKey>,

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/UnitAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/UnitAttestationHelper.kt
@@ -1,0 +1,97 @@
+package at.asitplus.wallet.app.common.attestation
+
+import at.asitplus.signum.indispensable.josef.JsonWebKey
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsHeader
+import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
+import at.asitplus.signum.indispensable.josef.toJsonWebKey
+import at.asitplus.wallet.app.common.HttpService
+import at.asitplus.wallet.app.common.WalletKeyMaterial
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.jws.JwsHeaderIdentifierFun
+import at.asitplus.wallet.lib.jws.SignJwt
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.appendEncodedPathSegments
+import io.ktor.http.contentType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+class UnitAttestationHelper(
+    val host: Flow<String>,
+    httpService: HttpService,
+    val keyMaterial: WalletKeyMaterial,
+) {
+    val unitEndpoint = host.map {
+        URLBuilder(host.first()).apply {
+            appendEncodedPathSegments(PATH_UNIT)
+        }
+    }
+    val httpClient = httpService.buildHttpClient()
+
+    suspend fun requestUnitAttestation(
+        instanceAttestation: JwsSigned<JsonWebToken>,
+        pop: JwsSigned<JsonWebToken>
+    ): JwsSigned<KeyAttestationJwt> {
+        val holderKey = keyMaterial.getUnderLyingSigner()
+
+        val response = httpClient.post(Url(unitEndpoint.first())) {
+            contentType(ContentType.Application.Json)
+            setBody(
+                UnitAttestationRequest(
+                    token = instanceAttestation.serialize(),
+                    keys = listOf(holderKey.publicKey.toJsonWebKey()),
+                    storageType = LOCAL_NATIVE,
+                    proof = pop.serialize()
+                )
+            )
+        }
+
+        return JwsSigned.deserialize<KeyAttestationJwt>(
+            it = response.bodyAsText(), deserializationStrategy = KeyAttestationJwt.serializer()
+        ).getOrThrow()
+    }
+
+    suspend fun buildProofOfPossession(
+        unitAttestation: JwsSigned<KeyAttestationJwt>,
+        type: String,
+        payload: JsonWebToken
+    ) =
+        keyMaterial.getUnderLyingSigner().let {
+            SignJwt<JsonWebToken>(
+                keyMaterial, JwsHeaderUnitAttestationPop(unitAttestation.serialize())
+            ).invoke(
+                type,
+                payload,
+                JsonWebToken.serializer(),
+            ).getOrThrow()
+        }
+}
+
+@Serializable
+data class UnitAttestationRequest(
+    @SerialName("token") val token: String,
+    @SerialName("proof") val proof: String,
+    @SerialName("keys") val keys: List<JsonWebKey>,
+    @SerialName("storage_type") val storageType: String,
+)
+
+/**
+ * JwsHeader for UnitAttestationPop
+ * kid value hardcoded to 0 see:
+ * https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md
+ */
+class JwsHeaderUnitAttestationPop(val wua: String) : JwsHeaderIdentifierFun {
+    override suspend operator fun invoke(
+        it: JwsHeader,
+        keyMaterial: KeyMaterial,
+    ) = it.copy(keyId = "0", keyAttestation = wua, jsonWebKey = keyMaterial.jsonWebKey)
+}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/UnitAttestationHelper.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/attestation/UnitAttestationHelper.kt
@@ -1,16 +1,14 @@
 package at.asitplus.wallet.app.common.attestation
 
+import at.asitplus.openid.DurationSecondsIntSerializer
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebToken
-import at.asitplus.signum.indispensable.josef.JwsHeader
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.app.common.HttpService
 import at.asitplus.wallet.app.common.WalletKeyMaterial
-import at.asitplus.wallet.lib.agent.KeyMaterial
-import at.asitplus.wallet.lib.jws.JwsHeaderIdentifierFun
-import at.asitplus.wallet.lib.jws.SignJwt
+import at.asitplus.wallet.lib.oidvci.WalletService.KeyAttestationInput
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -24,6 +22,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.Duration
 
 class UnitAttestationHelper(
     val host: Flow<String>,
@@ -39,7 +38,8 @@ class UnitAttestationHelper(
 
     suspend fun requestUnitAttestation(
         instanceAttestation: JwsSigned<JsonWebToken>,
-        pop: JwsSigned<JsonWebToken>
+        pop: JwsSigned<JsonWebToken>,
+        input: KeyAttestationInput,
     ): JwsSigned<KeyAttestationJwt> {
         val holderKey = keyMaterial.getUnderLyingSigner()
 
@@ -49,8 +49,11 @@ class UnitAttestationHelper(
                 UnitAttestationRequest(
                     token = instanceAttestation.serialize(),
                     keys = listOf(holderKey.publicKey.toJsonWebKey()),
-                    storageType = LOCAL_NATIVE,
-                    proof = pop.serialize()
+                    proof = pop.serialize(),
+                    nonce = input.clientNonce,
+                    credentialIssuer = input.credentialIssuer,
+                    preferredKeyStorageStatusPeriod = input.preferredKeyStorageStatusPeriod,
+                    supportedAlgorithms = input.supportedAlgorithms,
                 )
             )
         }
@@ -60,20 +63,6 @@ class UnitAttestationHelper(
         ).getOrThrow()
     }
 
-    suspend fun buildProofOfPossession(
-        unitAttestation: JwsSigned<KeyAttestationJwt>,
-        type: String,
-        payload: JsonWebToken
-    ) =
-        keyMaterial.getUnderLyingSigner().let {
-            SignJwt<JsonWebToken>(
-                keyMaterial, JwsHeaderUnitAttestationPop(unitAttestation.serialize())
-            ).invoke(
-                type,
-                payload,
-                JsonWebToken.serializer(),
-            ).getOrThrow()
-        }
 }
 
 @Serializable
@@ -81,17 +70,10 @@ data class UnitAttestationRequest(
     @SerialName("token") val token: String,
     @SerialName("proof") val proof: String,
     @SerialName("keys") val keys: List<JsonWebKey>,
-    @SerialName("storage_type") val storageType: String,
+    @SerialName("nonce") val nonce: String?,
+    @SerialName("credential_issuer") val credentialIssuer: String?,
+    @SerialName("preferred_key_storage_status_period")
+    @Serializable(with = DurationSecondsIntSerializer::class)
+    val preferredKeyStorageStatusPeriod: Duration?,
+    @SerialName("supported_algorithms") val supportedAlgorithms: Collection<String>?,
 )
-
-/**
- * JwsHeader for UnitAttestationPop
- * kid value hardcoded to 0 see:
- * https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md
- */
-class JwsHeaderUnitAttestationPop(val wua: String) : JwsHeaderIdentifierFun {
-    override suspend operator fun invoke(
-        it: JwsHeader,
-        keyMaterial: KeyMaterial,
-    ) = it.copy(keyId = "0", keyAttestation = wua, jsonWebKey = keyMaterial.jsonWebKey)
-}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/data/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/data/SettingsRepository.kt
@@ -26,6 +26,7 @@ import kotlin.time.Duration
 interface SettingsRepository {
     val host: Flow<String>
     val clientId: Flow<String>
+    val walletProviderHost: Flow<String>
     val isConditionsAccepted: Flow<Boolean>
     val presentmentUseNegotiatedHandover: Flow<Boolean>
     val presentmentBleCentralClientModeEnabled: Flow<Boolean>
@@ -47,6 +48,7 @@ interface SettingsRepository {
     fun set(
         host: String? = null,
         clientId: String? = null,
+        walletProviderHost: String? = null,
         isConditionsAccepted: Boolean? = null,
         presentmentUseNegotiatedHandover: Boolean? = null,
         presentmentBleCentralClientModeEnabled: Boolean? = null,

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/BuildAuthenticationConsentPageFromAuthenticationRequestDCAPIUseCase.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/BuildAuthenticationConsentPageFromAuthenticationRequestDCAPIUseCase.kt
@@ -1,13 +1,13 @@
 package at.asitplus.wallet.app.common.domain
 
 import at.asitplus.KmmResult
-import at.asitplus.dcapi.request.DCAPIWalletRequest
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import ui.navigation.routes.DCAPIAuthenticationConsentRoute
 import ui.navigation.routes.DCAPIPresentationViewRoute
 
 class BuildAuthenticationConsentPageFromAuthenticationRequestDCAPIUseCase {
-    operator fun invoke(incomingRequest: DCAPIWalletRequest?): KmmResult<DCAPIPresentationViewRoute> =
+    operator fun invoke(incomingRequest: RequestParametersFrom.IsoMdocDcApi?): KmmResult<DCAPIPresentationViewRoute> =
         incomingRequest?.let {
             KmmResult.success(
                 DCAPIPresentationViewRoute(joseCompliantSerializer.encodeToString(it))

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/communications/di/CommunicationsModule.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/communications/di/CommunicationsModule.kt
@@ -17,8 +17,8 @@ fun communicationsModule() = module {
     scope(named(SESSION_NAME)) {
         scopedOf(::ProvisioningService)
         scopedOf(::PresentationService)
+        scopedOf(::AttestationService)
     }
     singleOf(::SigningService)
     singleOf(::DCAPIExportService)
-    singleOf(::AttestationService)
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/communications/di/CommunicationsModule.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/communications/di/CommunicationsModule.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.app.common.domain.communications.di
 
+import at.asitplus.wallet.app.common.attestation.AttestationService
 import at.asitplus.wallet.app.common.HttpService
 import at.asitplus.wallet.app.common.PresentationService
 import at.asitplus.wallet.app.common.ProvisioningService
@@ -19,4 +20,5 @@ fun communicationsModule() = module {
     }
     singleOf(::SigningService)
     singleOf(::DCAPIExportService)
+    singleOf(::AttestationService)
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/platform/di/PlatformModule.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/platform/di/PlatformModule.kt
@@ -5,6 +5,7 @@ import at.asitplus.wallet.app.common.PlatformAdapter
 import at.asitplus.wallet.app.common.SESSION_NAME
 import at.asitplus.wallet.app.common.WalletDependencyProvider
 import at.asitplus.wallet.app.common.WalletKeyMaterial
+import at.asitplus.wallet.app.common.attestation.AttestationService
 import at.asitplus.wallet.app.common.decodeImage
 import at.asitplus.wallet.app.common.domain.platform.ImageDecoder
 import at.asitplus.wallet.app.common.domain.platform.UrlOpener

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/PublicKeyResolver.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/PublicKeyResolver.kt
@@ -4,7 +4,10 @@ import at.asitplus.openid.JwtVcIssuerMetadata
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdConstants.WellKnownPaths
 import at.asitplus.signum.indispensable.josef.JsonWebKey
+import at.asitplus.signum.indispensable.josef.JwsCompact
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.signum.indispensable.josef.toJwsFlattened
 import at.asitplus.wallet.app.common.HttpService
 import at.asitplus.wallet.lib.oauth2.OAuth2Utils.insertWellKnownPath
 import io.ktor.client.call.body
@@ -17,10 +20,10 @@ class PublicKeyResolver(
     val jsonWebKeySetResolver: JsonWebKeySetResolver,
     val httpService: HttpService
 ) {
-    suspend operator fun invoke(jws: JwsSigned<*>): Set<JsonWebKey>? =
-        if (jws.payloadIssuer() == "https://dss.aegean.gr/rfc-issuer" && jws.header.keyId != null) {
+    suspend operator fun invoke(jws: JwsCompact): Set<JsonWebKey>? =
+        if (jws.payloadIssuer() == "https://dss.aegean.gr/rfc-issuer" && jws.jwsHeader.keyId != null) {
             jsonWebKeySetResolver("https://dss.aegean.gr/.well-known/")
-                ?.keys?.firstOrNull { it.keyId == jws.header.keyId }?.let { setOf(it) }
+                ?.keys?.firstOrNull { it.keyId == jws.jwsHeader.keyId }?.let { setOf(it) }
         } else if (jws.payloadIssuer() != null) {
             httpService.buildHttpClient()
                 .get(insertWellKnownPath(jws.payloadIssuer()!!, WellKnownPaths.JwtVcIssuer))
@@ -30,6 +33,6 @@ class PublicKeyResolver(
                 }
         } else setOf()
 
-    private fun JwsSigned<*>.payloadIssuer() =
-        ((payload as? JsonObject?)?.get("iss") as? JsonPrimitive?)?.content
+    private fun JwsCompact.payloadIssuer() =
+        ((this.getPayload<JsonObject>().getOrNull()?.get("iss") as? JsonPrimitive?)?.content)
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/tokenStatusList/di/TokenStatusListModule.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/tokenStatusList/di/TokenStatusListModule.kt
@@ -1,6 +1,6 @@
 package at.asitplus.wallet.app.common.domain.vck.tokenStatusList.di
 
-import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.catching
 import at.asitplus.wallet.app.common.HttpService
 import at.asitplus.wallet.app.common.data.primitives.CacheStoreEntry
 import at.asitplus.wallet.app.common.data.primitives.CachingStatusListTokenResolver
@@ -20,6 +20,7 @@ import io.ktor.http.HttpHeaders
 import kotlin.time.Clock
 import org.koin.dsl.module
 import kotlin.time.Duration.Companion.seconds
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 
 
 fun tokenStatusListModule() = module {
@@ -49,10 +50,7 @@ fun tokenStatusListModule() = module {
                     headers[HttpHeaders.Accept] = MediaTypes.Application.STATUSLIST_JWT
                 }
                 StatusListJwt(
-                    JwsSigned.deserialize<StatusListTokenPayload>(
-                        StatusListTokenPayload.serializer(),
-                        httpResponse.bodyAsText()
-                    ).getOrThrow(),
+                    catching { JwsCompactTyped<StatusListTokenPayload>(httpResponse.bodyAsText()) }.getOrThrow(),
                     resolvedAt = Clock.System.now(),
                 )
             }

--- a/shared/src/commonMain/kotlin/domain/BuildAuthenticationConsentPageFromAuthenticationRequest.kt
+++ b/shared/src/commonMain/kotlin/domain/BuildAuthenticationConsentPageFromAuthenticationRequest.kt
@@ -2,7 +2,8 @@ package domain
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
-import at.asitplus.dcapi.request.DCAPIWalletRequest
+import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.wallet.app.common.PresentationService
 import io.github.aakira.napier.Napier
 import ui.navigation.routes.AuthenticationViewRoute
@@ -11,7 +12,7 @@ class BuildAuthenticationConsentPageFromAuthenticationRequest(
     val presentationService: PresentationService,
 ) {
     suspend operator fun invoke(
-        request: DCAPIWalletRequest.OpenId4Vp,
+        request: RequestParametersFrom<AuthenticationRequestParameters>,
     ): KmmResult<AuthenticationViewRoute> = catching {
         val preparationState = presentationService.startAuthorizationResponsePreparation(request)
             .onFailure { Napier.e("Failure", it) }

--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -642,6 +642,7 @@ private fun WalletNavHost(
                 onClickFAQs = null,
                 onClickDataProtectionPolicy = null,
                 onClickLicenses = null,
+                onClickAttestation = { navigate(AttestationSettingsRoute) },
                 onReset = { navigateNewGraph(InitializationRoute) },
                 koinScope = koinScope
             )
@@ -883,6 +884,14 @@ private fun WalletNavHost(
                     prerequisites = prerequisites,
                 )
             }
+        }
+        composable<AttestationSettingsRoute> {
+            AttestationSettingsView(
+                onClickLogo = onClickLogo,
+                onClickBack = navigateBack,
+                onClickSettings = navigateBack,
+                vm  = remember { AttestationSettingsViewModel(walletMain.attestationService) }
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/WalletNavigation.kt
@@ -890,7 +890,10 @@ private fun WalletNavHost(
                 onClickLogo = onClickLogo,
                 onClickBack = navigateBack,
                 onClickSettings = navigateBack,
-                vm  = remember { AttestationSettingsViewModel(walletMain.attestationService) }
+                vm  = remember { AttestationSettingsViewModel(walletMain.attestationService) },
+                onError = {
+                    walletMain.errorService.emit(it)
+                }
             )
         }
     }

--- a/shared/src/commonMain/kotlin/ui/navigation/routes/WalletRoutes.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/routes/WalletRoutes.kt
@@ -216,3 +216,5 @@ data class CapabilitiesRoute(val prerequisitesSerialized: String) : Route() {
 
 @Serializable
 object RefreshCenterRoute
+@Serializable
+object AttestationSettingsRoute : Route()

--- a/shared/src/commonMain/kotlin/ui/presentation/DCAPIPresentationGraphView.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/DCAPIPresentationGraphView.kt
@@ -43,7 +43,7 @@ fun DCAPIPresentationGraphView(
         selectionProvider = matchingResult.map {
             it.second
         },
-        submitPresentation = SubmitPresentation { it, navigate ->
+        submitPresentation = { it, navigate ->
             viewModel.confirmSelection(
                 credentialPresentationSubmissions = it,
                 onFailure = onError,

--- a/shared/src/commonMain/kotlin/ui/presentation/DCAPIPresentationGraphViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/DCAPIPresentationGraphViewModel.kt
@@ -5,8 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import at.asitplus.catching
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.dif.PresentationDefinition
+import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.biometric_authentication_prompt_for_data_transmission_consent_title
 import at.asitplus.wallet.app.common.WalletMain
@@ -14,7 +15,6 @@ import at.asitplus.wallet.app.common.toDifInputDescriptorList
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.lib.ktor.openid.OpenId4VpWallet
 import at.asitplus.wallet.lib.openid.PresentationExchangeMatchingResult
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,16 +34,17 @@ class DCAPIPresentationGraphViewModel(
     val apiRequestSerialized = route.apiRequestSerialized
 
     val dcApiWalletRequest = catching {
-        joseCompliantSerializer.decodeFromString<DCAPIWalletRequest.IsoMdoc>(apiRequestSerialized)
+        joseCompliantSerializer.decodeFromString<RequestParametersFrom.IsoMdocDcApi>(apiRequestSerialized)
     }
 
-    val selectionProvider = MutableStateFlow<UiState<Pair<DCAPIWalletRequest.IsoMdoc, CredentialSelectionProvider<SubjectCredentialStore.StoreEntry>>>>(
+    val selectionProvider = MutableStateFlow<UiState<Pair<RequestParametersFrom.IsoMdocDcApi, CredentialSelectionProvider<SubjectCredentialStore.StoreEntry>>>>(
         UiStateLoading
     ).apply {
         viewModelScope.launch {
             value = try {
                 val unwrappedDcApiWalletRequest = dcApiWalletRequest.getOrThrow()
-                val descriptors = unwrappedDcApiWalletRequest.isoMdocRequest.deviceRequest.docRequests.toDifInputDescriptorList()
+                val descriptors =
+                    unwrappedDcApiWalletRequest.parameters.isoMdocRequest.deviceRequest.docRequests.toDifInputDescriptorList()
                 val presentationRequest = CredentialPresentationRequest.PresentationExchangeRequest(
                     presentationDefinition = PresentationDefinition(
                         inputDescriptors = descriptors
@@ -107,7 +108,7 @@ class DCAPIPresentationGraphViewModel(
 
     private suspend fun finalizeAuthorization(
         credentialPresentation: CredentialPresentation,
-        request: DCAPIWalletRequest.IsoMdoc
+        request: RequestParametersFrom.IsoMdocDcApi
     ): OpenId4VpWallet.AuthenticationSuccess {
         walletMain.keyMaterial.promptText =
             getString(Res.string.biometric_authentication_prompt_for_data_transmission_consent_title)
@@ -119,7 +120,7 @@ class DCAPIPresentationGraphViewModel(
 
     private suspend fun finalizationMethod(
         credentialPresentation: CredentialPresentation,
-        request: DCAPIWalletRequest.IsoMdoc
+        request: RequestParametersFrom.IsoMdocDcApi
     ): OpenId4VpWallet.AuthenticationSuccess = walletMain.presentationService.finalizeDCAPIIsoMdocPresentation(
         credentialPresentation = when (credentialPresentation) {
             is CredentialPresentation.PresentationExchangePresentation -> credentialPresentation

--- a/shared/src/commonMain/kotlin/ui/presentation/DefaultPresentationGraphViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/DefaultPresentationGraphViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import at.asitplus.catching
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.biometric_authentication_prompt_for_data_transmission_consent_title
@@ -36,11 +35,7 @@ class DefaultPresentationGraphViewModel(
     }
 
     val dcApiRequest = preparationState.map {
-        when (val request = it.request) {
-            is RequestParametersFrom.DcApiSigned -> request.dcApiRequest
-            is RequestParametersFrom.DcApiUnsigned -> request.dcApiRequest
-            else -> null
-        } as? DCAPIWalletRequest
+        it.request as? RequestParametersFrom.DcApiRequest
     }
 
     val selectionProvider = MutableStateFlow<UiState<CredentialSelectionProvider<SubjectCredentialStore.StoreEntry>>>(
@@ -130,4 +125,3 @@ class DefaultPresentationGraphViewModel(
 internal fun serializeDcApiPresentationResponse(
     authenticationResponseResult: AuthenticationResponseResult.DcApi,
 ) = joseCompliantSerializer.encodeToString(authenticationResponseResult.params.data)
-

--- a/shared/src/commonMain/kotlin/ui/viewmodels/AttestationSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/AttestationSettingsViewModel.kt
@@ -5,6 +5,7 @@ import at.asitplus.wallet.app.common.attestation.AttestationService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 
 class AttestationSettingsViewModel(
@@ -12,7 +13,10 @@ class AttestationSettingsViewModel(
 ) : ViewModel() {
     val scope = CoroutineScope(Dispatchers.IO)
 
+    val onError = MutableSharedFlow<Throwable>()
     fun preload() = scope.launch {
-        attestationService.preloadAttestation()
+        attestationService.preloadAttestation().onFailure {
+            onError.emit(Throwable("Unable to obtain attestation from wallet provider.", it))
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/ui/viewmodels/AttestationSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/AttestationSettingsViewModel.kt
@@ -1,0 +1,18 @@
+package ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import at.asitplus.wallet.app.common.attestation.AttestationService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.launch
+
+class AttestationSettingsViewModel(
+    val attestationService: AttestationService
+) : ViewModel() {
+    val scope = CoroutineScope(Dispatchers.IO)
+
+    fun preload() = scope.launch {
+        attestationService.preloadAttestation()
+    }
+}

--- a/shared/src/commonMain/kotlin/ui/viewmodels/AttestationSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/AttestationSettingsViewModel.kt
@@ -14,9 +14,14 @@ class AttestationSettingsViewModel(
     val scope = CoroutineScope(Dispatchers.IO)
 
     val onError = MutableSharedFlow<Throwable>()
-    fun preload() = scope.launch {
-        attestationService.preloadAttestation().onFailure {
-            onError.emit(Throwable("Unable to obtain attestation from wallet provider.", it))
+    fun preloadKeyAttestation() = scope.launch {
+        attestationService.preloadKeyAttestation().onFailure {
+            onError.emit(Throwable("Unable to obtain key attestation from wallet provider.", it))
+        }
+    }
+    fun preloadInstanceAttestation() = scope.launch {
+        attestationService.preloadInstanceAttestation().onFailure {
+            onError.emit(Throwable("Unable to obtain instance attestation from wallet provider.", it))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/ui/viewmodels/intents/DCAPIAuthorizationIntentViewModel.kt
+++ b/shared/src/commonMain/kotlin/ui/viewmodels/intents/DCAPIAuthorizationIntentViewModel.kt
@@ -1,12 +1,10 @@
 package ui.viewmodels.intents
 
-import at.asitplus.dcapi.request.DCAPIWalletRequest
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.wallet.app.common.WalletMain
 import at.asitplus.wallet.app.common.domain.BuildAuthenticationConsentPageFromAuthenticationRequestDCAPIUseCase
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import domain.BuildAuthenticationConsentPageFromAuthenticationRequest
-import domain.BuildAuthenticationConsentPageFromAuthenticationRequestUriUseCase
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
@@ -38,11 +36,13 @@ class DCAPIAuthorizationIntentViewModel(
     }
 
     fun process() = walletMain.scope.launch(Dispatchers.Default + coroutineExceptionHandler) {
-        val dcApiRequest = walletMain.platformAdapter.getCurrentDCAPIData().getOrThrow()
+        val dcApiRequest = walletMain.platformAdapter.getCurrentDCAPIVerificationData().getOrThrow()
 
         val successRoute = when (dcApiRequest) {
-            is DCAPIWalletRequest.OpenId4Vp -> buildConsentPageFromRequest(dcApiRequest)
-            is DCAPIWalletRequest.IsoMdoc -> buildConsentPageFromDcApiRequest(dcApiRequest)
+            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> TODO()
+            is RequestParametersFrom.OpenId4VpDcApiSigned -> buildConsentPageFromRequest(dcApiRequest)
+            is RequestParametersFrom.OpenId4VpDcApiUnsigned -> buildConsentPageFromRequest(dcApiRequest)
+            is RequestParametersFrom.IsoMdocDcApi -> buildConsentPageFromDcApiRequest(dcApiRequest)
         }.getOrThrow()
 
         onSuccess(successRoute)

--- a/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
@@ -1,0 +1,137 @@
+package ui.views
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.modifier.modifierLocalProvider
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import at.asitplus.valera.resources.Res
+import at.asitplus.valera.resources.button_label_load_attestation
+import at.asitplus.valera.resources.heading_label_attestation
+import at.asitplus.valera.resources.text_label_attestation_expiration
+import at.asitplus.valera.resources.text_label_attestation_issued
+import at.asitplus.valera.resources.text_label_attestation_storage_type
+import at.asitplus.valera.resources.text_label_instance_attestation
+import at.asitplus.valera.resources.text_label_unit_attestation
+import at.asitplus.valera.resources.text_label_wallet_provider
+import org.jetbrains.compose.resources.stringResource
+import ui.composables.LabeledText
+import ui.composables.Logo
+import ui.composables.ScreenHeading
+import ui.composables.buttons.NavigateUpButton
+import ui.viewmodels.AttestationSettingsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AttestationSettingsView(
+    onClickLogo: () -> Unit,
+    onClickBack: () -> Unit,
+    onClickSettings: () -> Unit,
+    vm: AttestationSettingsViewModel
+) {
+    val bufferedInstanceAttestation = vm.attestationService.bufferedInstanceAttestation.collectAsState(null)
+    val bufferedUnitAttestation = vm.attestationService.bufferedUnitAttestation.collectAsState(null)
+
+    vm.attestationService.getWalletProviderHost().collectAsState(null).value?.let { it ->
+        var host by remember { mutableStateOf(it) }
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            ScreenHeading(
+                                stringResource(Res.string.heading_label_attestation),
+                                Modifier.weight(1f)
+                            )
+                        }
+                    },
+                    actions = {
+                        Logo(onClick = onClickLogo)
+                        Column(modifier = Modifier.clickable(onClick = {
+                            vm.attestationService.setWalletProviderHost(host)
+                            onClickSettings()
+                        })) {
+                            Icon(
+                                imageVector = Icons.Outlined.Settings,
+                                contentDescription = null,
+                            )
+                        }
+                        Spacer(Modifier.width(15.dp))
+                    },
+                    navigationIcon = {
+                        NavigateUpButton(onClick = {
+                            vm.attestationService.setWalletProviderHost(host)
+                            onClickBack()
+                        })
+                    },
+                )
+            }
+        ) { scaffoldPadding ->
+            Box(modifier = Modifier.padding(scaffoldPadding)) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 16.dp).verticalScroll(rememberScrollState())
+                ) {
+                    OutlinedTextField(
+                        label = {
+                            Text(stringResource(Res.string.text_label_wallet_provider))
+                        },
+                        singleLine = true,
+                        readOnly = false,
+                        value = host,
+                        onValueChange = { host = it },
+                        enabled = true,
+                        modifier = Modifier,
+                    )
+                    Spacer(Modifier.height(10.dp))
+                    bufferedInstanceAttestation.value?.let {
+                        Text(stringResource(Res.string.text_label_instance_attestation), fontWeight = FontWeight.Bold)
+                        LabeledText(text = "${it.payload.issuedAt}", label = stringResource(Res.string.text_label_attestation_issued))
+                        LabeledText(text = "${it.payload.expiration}", label = stringResource(Res.string.text_label_attestation_expiration))
+                    }
+                    Spacer(Modifier.height(20.dp))
+                    bufferedUnitAttestation.value?.let {
+                        Text(stringResource(Res.string.text_label_unit_attestation), fontWeight = FontWeight.Bold)
+                        LabeledText(text = "${it.payload.issuedAt}", label = stringResource(Res.string.text_label_attestation_issued))
+                        LabeledText(text = "${it.payload.expiration}", label = stringResource(Res.string.text_label_attestation_expiration))
+                        LabeledText(text = "${it.payload.eudiWalletInfo?.keyStorageInfo?.storageType}", label = stringResource(Res.string.text_label_attestation_storage_type))
+                    }
+                    if (bufferedUnitAttestation.value == null || bufferedInstanceAttestation.value == null) {
+                        Button(onClick = {
+                            vm.attestationService.setWalletProviderHost(host)
+                            vm.preload()
+                        }) {
+                            Text(stringResource(Res.string.button_label_load_attestation))
+                        }
+                    }
+                }
+            }
+        }
+    } ?: LoadingView()
+}

--- a/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -30,7 +29,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.modifier.modifierLocalProvider
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.asitplus.valera.resources.Res
@@ -116,15 +114,30 @@ fun AttestationSettingsView(
                     Spacer(Modifier.height(10.dp))
                     bufferedInstanceAttestation.value?.let {
                         Text(stringResource(Res.string.text_label_instance_attestation), fontWeight = FontWeight.Bold)
-                        LabeledText(text = "${it.payload.issuedAt}", label = stringResource(Res.string.text_label_attestation_issued))
-                        LabeledText(text = "${it.payload.expiration}", label = stringResource(Res.string.text_label_attestation_expiration))
+                        LabeledText(
+                            text = "${it.payload.issuedAt}",
+                            label = stringResource(Res.string.text_label_attestation_issued)
+                        )
+                        LabeledText(
+                            text = "${it.payload.expiration}",
+                            label = stringResource(Res.string.text_label_attestation_expiration)
+                        )
                     }
                     Spacer(Modifier.height(20.dp))
                     bufferedUnitAttestation.value?.let {
                         Text(stringResource(Res.string.text_label_unit_attestation), fontWeight = FontWeight.Bold)
-                        LabeledText(text = "${it.payload.issuedAt}", label = stringResource(Res.string.text_label_attestation_issued))
-                        LabeledText(text = "${it.payload.expiration}", label = stringResource(Res.string.text_label_attestation_expiration))
-                        LabeledText(text = "${it.payload.eudiWalletInfo?.keyStorageInfo?.storageType}", label = stringResource(Res.string.text_label_attestation_storage_type))
+                        LabeledText(
+                            text = "${it.payload.issuedAt}",
+                            label = stringResource(Res.string.text_label_attestation_issued)
+                        )
+                        LabeledText(
+                            text = "${it.payload.expiration}",
+                            label = stringResource(Res.string.text_label_attestation_expiration)
+                        )
+                        LabeledText(
+                            text = "${it.payload.eudiWalletInfo?.keyStorageInfo?.storageType}",
+                            label = stringResource(Res.string.text_label_attestation_storage_type)
+                        )
                     }
                     if (bufferedUnitAttestation.value == null || bufferedInstanceAttestation.value == null) {
                         Button(onClick = {

--- a/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
@@ -135,7 +135,7 @@ fun AttestationSettingsView(
                             label = stringResource(Res.string.text_label_attestation_expiration)
                         )
                         LabeledText(
-                            text = "${it.payload.eudiWalletInfo?.keyStorageInfo?.storageType}",
+                            text = it.payload.keyStorage?.joinToString().orEmpty(),
                             label = stringResource(Res.string.text_label_attestation_storage_type)
                         )
                     }

--- a/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -54,8 +55,11 @@ fun AttestationSettingsView(
     onClickLogo: () -> Unit,
     onClickBack: () -> Unit,
     onClickSettings: () -> Unit,
+    onError: (Throwable) -> Unit,
     vm: AttestationSettingsViewModel
 ) {
+    LaunchedEffect(null) { vm.onError.collect { onError(it) } }
+
     val bufferedInstanceAttestation = vm.attestationService.bufferedInstanceAttestation.collectAsState(null)
     val bufferedUnitAttestation = vm.attestationService.bufferedUnitAttestation.collectAsState(null)
 

--- a/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
@@ -36,7 +36,9 @@ import at.asitplus.valera.resources.button_label_load_attestation
 import at.asitplus.valera.resources.heading_label_attestation
 import at.asitplus.valera.resources.text_label_attestation_expiration
 import at.asitplus.valera.resources.text_label_attestation_issued
+import at.asitplus.valera.resources.text_label_attestation_status_expiration
 import at.asitplus.valera.resources.text_label_attestation_storage_type
+import at.asitplus.valera.resources.text_label_attestation_user_authentication
 import at.asitplus.valera.resources.text_label_instance_attestation
 import at.asitplus.valera.resources.text_label_unit_attestation
 import at.asitplus.valera.resources.text_label_wallet_provider
@@ -59,7 +61,7 @@ fun AttestationSettingsView(
     LaunchedEffect(null) { vm.onError.collect { onError(it) } }
 
     val bufferedInstanceAttestation = vm.attestationService.bufferedInstanceAttestation.collectAsState(null)
-    val bufferedUnitAttestation = vm.attestationService.bufferedUnitAttestation.collectAsState(null)
+    val bufferedKeyAttestation = vm.attestationService.bufferedKeyAttestation.collectAsState(null)
 
     vm.attestationService.getWalletProviderHost().collectAsState(null).value?.let { it ->
         var host by remember { mutableStateOf(it) }
@@ -77,7 +79,7 @@ fun AttestationSettingsView(
                     actions = {
                         Logo(onClick = onClickLogo)
                         Column(modifier = Modifier.clickable(onClick = {
-                            vm.attestationService.setWalletProviderHost(host)
+                            if(host != it) vm.attestationService.setWalletProviderHost(host)
                             onClickSettings()
                         })) {
                             Icon(
@@ -89,7 +91,7 @@ fun AttestationSettingsView(
                     },
                     navigationIcon = {
                         NavigateUpButton(onClick = {
-                            vm.attestationService.setWalletProviderHost(host)
+                            if(host != it) vm.attestationService.setWalletProviderHost(host)
                             onClickBack()
                         })
                     },
@@ -112,37 +114,69 @@ fun AttestationSettingsView(
                         modifier = Modifier,
                     )
                     Spacer(Modifier.height(10.dp))
+                    Text(stringResource(Res.string.text_label_instance_attestation), fontWeight = FontWeight.Bold)
                     bufferedInstanceAttestation.value?.let {
-                        Text(stringResource(Res.string.text_label_instance_attestation), fontWeight = FontWeight.Bold)
-                        LabeledText(
-                            text = "${it.payload.issuedAt}",
-                            label = stringResource(Res.string.text_label_attestation_issued)
-                        )
-                        LabeledText(
-                            text = "${it.payload.expiration}",
-                            label = stringResource(Res.string.text_label_attestation_expiration)
-                        )
+                        it.payload.issuedAt?.let { issuedAt ->
+                            LabeledText(
+                                text = "$issuedAt",
+                                label = stringResource(Res.string.text_label_attestation_issued)
+                            )
+                        }
+                        it.payload.expiration?.let { expiration ->
+                            LabeledText(
+                                text = "$expiration",
+                                label = stringResource(Res.string.text_label_attestation_expiration)
+                            )
+                        }
+                        it.payload.clientStatus?.expiration?.let { expiration ->
+                            LabeledText(
+                                text = "$expiration",
+                                label = stringResource(Res.string.text_label_attestation_status_expiration)
+                            )
+                        }
+                    } ?: run {
+                        Button(onClick = {
+                            if(host != it) vm.attestationService.setWalletProviderHost(host)
+                            vm.preloadInstanceAttestation()
+                        }) {
+                            Text(stringResource(Res.string.button_label_load_attestation))
+                        }
                     }
                     Spacer(Modifier.height(20.dp))
-                    bufferedUnitAttestation.value?.let {
-                        Text(stringResource(Res.string.text_label_unit_attestation), fontWeight = FontWeight.Bold)
+                    Text(stringResource(Res.string.text_label_unit_attestation), fontWeight = FontWeight.Bold)
+                    bufferedKeyAttestation.value?.let {
                         LabeledText(
                             text = "${it.payload.issuedAt}",
                             label = stringResource(Res.string.text_label_attestation_issued)
                         )
-                        LabeledText(
-                            text = "${it.payload.expiration}",
-                            label = stringResource(Res.string.text_label_attestation_expiration)
-                        )
-                        LabeledText(
-                            text = it.payload.keyStorage?.joinToString().orEmpty(),
-                            label = stringResource(Res.string.text_label_attestation_storage_type)
-                        )
-                    }
-                    if (bufferedUnitAttestation.value == null || bufferedInstanceAttestation.value == null) {
+                        it.payload.expiration?.let { expiration ->
+                            LabeledText(
+                                text = "${it.payload.expiration}",
+                                label = stringResource(Res.string.text_label_attestation_expiration)
+                            )
+                        }
+                        it.payload.keyStorageStatus?.expiration?.let { expiration ->
+                            LabeledText(
+                                text = "$expiration",
+                                label = stringResource(Res.string.text_label_attestation_status_expiration)
+                            )
+                        }
+                        it.payload.keyStorage?.let { keyStorage ->
+                            LabeledText(
+                                text = keyStorage.joinToString(),
+                                label = stringResource(Res.string.text_label_attestation_storage_type)
+                            )
+                        }
+                        it.payload.userAuthentication?.let { userAuthentication ->
+                            LabeledText(
+                                text = userAuthentication.joinToString(),
+                                label = stringResource(Res.string.text_label_attestation_user_authentication)
+                            )
+                        }
+                    } ?: run {
                         Button(onClick = {
-                            vm.attestationService.setWalletProviderHost(host)
-                            vm.preload()
+                            if(host != it) vm.attestationService.setWalletProviderHost(host)
+                            vm.preloadKeyAttestation()
                         }) {
                             Text(stringResource(Res.string.button_label_load_attestation))
                         }

--- a/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/AttestationSettingsView.kt
@@ -16,9 +16,11 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,8 +34,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import at.asitplus.valera.resources.Res
+import at.asitplus.valera.resources.button_label_attestation_apply
 import at.asitplus.valera.resources.button_label_load_attestation
 import at.asitplus.valera.resources.heading_label_attestation
+import at.asitplus.valera.resources.section_heading_attestation_certificates
+import at.asitplus.valera.resources.section_heading_general
 import at.asitplus.valera.resources.text_label_attestation_expiration
 import at.asitplus.valera.resources.text_label_attestation_issued
 import at.asitplus.valera.resources.text_label_attestation_status_expiration
@@ -62,9 +67,8 @@ fun AttestationSettingsView(
 
     val bufferedInstanceAttestation = vm.attestationService.bufferedInstanceAttestation.collectAsState(null)
     val bufferedKeyAttestation = vm.attestationService.bufferedKeyAttestation.collectAsState(null)
-
-    vm.attestationService.getWalletProviderHost().collectAsState(null).value?.let { it ->
-        var host by remember { mutableStateOf(it) }
+    vm.attestationService.getWalletProviderHost().collectAsState(null).value?.let { host ->
+        var hostInput by remember { mutableStateOf(host) }
         Scaffold(
             topBar = {
                 TopAppBar(
@@ -79,7 +83,6 @@ fun AttestationSettingsView(
                     actions = {
                         Logo(onClick = onClickLogo)
                         Column(modifier = Modifier.clickable(onClick = {
-                            if(host != it) vm.attestationService.setWalletProviderHost(host)
                             onClickSettings()
                         })) {
                             Icon(
@@ -91,7 +94,6 @@ fun AttestationSettingsView(
                     },
                     navigationIcon = {
                         NavigateUpButton(onClick = {
-                            if(host != it) vm.attestationService.setWalletProviderHost(host)
                             onClickBack()
                         })
                     },
@@ -99,86 +101,130 @@ fun AttestationSettingsView(
             }
         ) { scaffoldPadding ->
             Box(modifier = Modifier.padding(scaffoldPadding)) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp).verticalScroll(rememberScrollState())
-                ) {
-                    OutlinedTextField(
-                        label = {
-                            Text(stringResource(Res.string.text_label_wallet_provider))
-                        },
-                        singleLine = true,
-                        readOnly = false,
-                        value = host,
-                        onValueChange = { host = it },
-                        enabled = true,
-                        modifier = Modifier,
-                    )
-                    Spacer(Modifier.height(10.dp))
-                    Text(stringResource(Res.string.text_label_instance_attestation), fontWeight = FontWeight.Bold)
-                    bufferedInstanceAttestation.value?.let {
-                        it.payload.issuedAt?.let { issuedAt ->
-                            LabeledText(
-                                text = "$issuedAt",
-                                label = stringResource(Res.string.text_label_attestation_issued)
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    Column(
+                        modifier = Modifier.padding(end = 16.dp, start = 16.dp)
+                    ) {
+                        val layoutSpacingModifier = Modifier.padding(top = 24.dp)
+
+                        Column(
+                            modifier = layoutSpacingModifier
+                        ) {
+                            val listSpacingModifier = Modifier.padding(top = 8.dp)
+                            Text(
+                                text = stringResource(Res.string.section_heading_general),
+                                style = MaterialTheme.typography.titleMedium,
                             )
-                        }
-                        it.payload.expiration?.let { expiration ->
-                            LabeledText(
-                                text = "$expiration",
-                                label = stringResource(Res.string.text_label_attestation_expiration)
-                            )
-                        }
-                        it.payload.clientStatus?.expiration?.let { expiration ->
-                            LabeledText(
-                                text = "$expiration",
-                                label = stringResource(Res.string.text_label_attestation_status_expiration)
-                            )
-                        }
-                    } ?: run {
-                        Button(onClick = {
-                            if(host != it) vm.attestationService.setWalletProviderHost(host)
-                            vm.preloadInstanceAttestation()
-                        }) {
-                            Text(stringResource(Res.string.button_label_load_attestation))
-                        }
-                    }
-                    Spacer(Modifier.height(20.dp))
-                    Text(stringResource(Res.string.text_label_unit_attestation), fontWeight = FontWeight.Bold)
-                    bufferedKeyAttestation.value?.let {
-                        LabeledText(
-                            text = "${it.payload.issuedAt}",
-                            label = stringResource(Res.string.text_label_attestation_issued)
-                        )
-                        it.payload.expiration?.let { expiration ->
-                            LabeledText(
-                                text = "${it.payload.expiration}",
-                                label = stringResource(Res.string.text_label_attestation_expiration)
-                            )
-                        }
-                        it.payload.keyStorageStatus?.expiration?.let { expiration ->
-                            LabeledText(
-                                text = "$expiration",
-                                label = stringResource(Res.string.text_label_attestation_status_expiration)
-                            )
-                        }
-                        it.payload.keyStorage?.let { keyStorage ->
-                            LabeledText(
-                                text = keyStorage.joinToString(),
-                                label = stringResource(Res.string.text_label_attestation_storage_type)
-                            )
-                        }
-                        it.payload.userAuthentication?.let { userAuthentication ->
-                            LabeledText(
-                                text = userAuthentication.joinToString(),
-                                label = stringResource(Res.string.text_label_attestation_user_authentication)
-                            )
-                        }
-                    } ?: run {
-                        Button(onClick = {
-                            if(host != it) vm.attestationService.setWalletProviderHost(host)
-                            vm.preloadKeyAttestation()
-                        }) {
-                            Text(stringResource(Res.string.button_label_load_attestation))
+                            Row(
+                                modifier = listSpacingModifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                OutlinedTextField(
+                                    label = {
+                                        Text(stringResource(Res.string.text_label_wallet_provider))
+                                    },
+                                    singleLine = true,
+                                    readOnly = false,
+                                    value = hostInput,
+                                    onValueChange = { hostInput = it },
+                                    enabled = true,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                TextButton(
+                                    onClick = {
+                                        vm.attestationService.setWalletProviderHost(hostInput)
+                                    }, enabled = hostInput != host
+                                ) {
+                                    Text(stringResource(Res.string.button_label_attestation_apply))
+                                }
+                            }
+
+
+                            Column(
+                                modifier = layoutSpacingModifier
+                            ) {
+                                val listSpacingModifier = Modifier.padding(top = 8.dp)
+                                Column(modifier = listSpacingModifier.fillMaxWidth()) {
+                                    Text(
+                                        text = stringResource(Res.string.section_heading_attestation_certificates),
+                                        style = MaterialTheme.typography.titleMedium,
+                                    )
+                                    Text(
+                                        stringResource(Res.string.text_label_instance_attestation),
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                    bufferedInstanceAttestation.value?.let {
+                                        it.payload.issuedAt?.let { issuedAt ->
+                                            LabeledText(
+                                                text = "$issuedAt",
+                                                label = stringResource(Res.string.text_label_attestation_issued)
+                                            )
+                                        }
+                                        it.payload.expiration?.let { expiration ->
+                                            LabeledText(
+                                                text = "$expiration",
+                                                label = stringResource(Res.string.text_label_attestation_expiration)
+                                            )
+                                        }
+                                        it.payload.clientStatus?.expiration?.let { expiration ->
+                                            LabeledText(
+                                                text = "$expiration",
+                                                label = stringResource(Res.string.text_label_attestation_status_expiration)
+                                            )
+                                        }
+                                    } ?: run {
+                                        Button(onClick = {
+                                            vm.preloadInstanceAttestation()
+                                        }) {
+                                            Text(stringResource(Res.string.button_label_load_attestation))
+                                        }
+                                    }
+                                    Spacer(Modifier.height(20.dp))
+                                    Text(
+                                        stringResource(Res.string.text_label_unit_attestation),
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                    bufferedKeyAttestation.value?.let {
+                                        LabeledText(
+                                            text = "${it.payload.issuedAt}",
+                                            label = stringResource(Res.string.text_label_attestation_issued)
+                                        )
+                                        it.payload.expiration?.let { expiration ->
+                                            LabeledText(
+                                                text = "${it.payload.expiration}",
+                                                label = stringResource(Res.string.text_label_attestation_expiration)
+                                            )
+                                        }
+                                        it.payload.keyStorageStatus?.expiration?.let { expiration ->
+                                            LabeledText(
+                                                text = "$expiration",
+                                                label = stringResource(Res.string.text_label_attestation_status_expiration)
+                                            )
+                                        }
+                                        it.payload.keyStorage?.let { keyStorage ->
+                                            LabeledText(
+                                                text = keyStorage.joinToString(),
+                                                label = stringResource(Res.string.text_label_attestation_storage_type)
+                                            )
+                                        }
+                                        it.payload.userAuthentication?.let { userAuthentication ->
+                                            LabeledText(
+                                                text = userAuthentication.joinToString(),
+                                                label = stringResource(Res.string.text_label_attestation_user_authentication)
+                                            )
+                                        }
+                                    } ?: run {
+                                        Button(onClick = {
+                                            vm.preloadKeyAttestation()
+                                        }) {
+                                            Text(stringResource(Res.string.button_label_load_attestation))
+                                        }
+                                    }
+                                }
+
+
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/ui/views/SettingsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/SettingsView.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.SettingsBackupRestore
 import androidx.compose.material.icons.outlined.Share
@@ -45,6 +46,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import at.asitplus.valera.resources.Res
+import at.asitplus.valera.resources.button_label_attestation_config
 import at.asitplus.valera.resources.button_label_clear_log
 import at.asitplus.valera.resources.button_label_confirm
 import at.asitplus.valera.resources.button_label_data_protection_policy
@@ -94,6 +96,7 @@ fun SettingsView(
     onClickFAQs: (() -> Unit)?,
     onClickDataProtectionPolicy: (() -> Unit)?,
     onClickLicenses: (() -> Unit)?,
+    onClickAttestation: () -> Unit,
     koinScope: Scope,
     onReset: () -> Unit,
     settingsViewModel: SettingsViewModel = koinViewModel(scope = koinScope),
@@ -298,6 +301,17 @@ fun SettingsView(
                                     }
                                 }
                             },
+                            modifier = listSpacingModifier.fillMaxWidth(),
+                        )
+                        TextIconButtonListItem(
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Key,
+                                    contentDescription = null,
+                                )
+                            },
+                            label = stringResource(Res.string.button_label_attestation_config),
+                            onClick = { onClickAttestation() },
                             modifier = listSpacingModifier.fillMaxWidth(),
                         )
                         TextIconButtonListItem(

--- a/shared/src/iosMain/kotlin/main.ios.kt
+++ b/shared/src/iosMain/kotlin/main.ios.kt
@@ -4,29 +4,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.ComposeUIViewController
 import at.asitplus.KmmResult
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.iso.EncryptionParameters
-import at.asitplus.wallet.app.common.BuildContext
-import at.asitplus.wallet.app.common.CapabilitiesService
-import at.asitplus.wallet.app.common.KeystoreService
-import at.asitplus.wallet.app.common.PlatformAdapter
-import at.asitplus.wallet.app.common.RealCapabilitiesService
-import at.asitplus.wallet.app.common.SESSION_NAME
-import at.asitplus.wallet.app.common.WalletDependencyProvider
+import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.wallet.app.common.*
 import at.asitplus.wallet.app.common.dcapi.data.export.CredentialRegistry
 import at.asitplus.wallet.app.common.di.appModule
 import data.storage.RealDataStoreService
 import data.storage.createDataStore
 import io.github.aakira.napier.Napier
-import kotlinx.cinterop.BetaInteropApi
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.ObjCObjectVar
-import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.ptr
-import kotlinx.cinterop.usePinned
-import kotlinx.cinterop.value
+import kotlinx.cinterop.*
 import kotlinx.coroutines.CoroutineScope
 import org.koin.core.module.dsl.scopedOf
 import org.koin.core.qualifier.named
@@ -34,36 +20,9 @@ import org.koin.dsl.binds
 import org.koin.dsl.module
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.prompt.IosPromptModel
-import platform.AVFoundation.AVAuthorizationStatusAuthorized
-import platform.AVFoundation.AVAuthorizationStatusDenied
-import platform.AVFoundation.AVAuthorizationStatusNotDetermined
-import platform.AVFoundation.AVAuthorizationStatusRestricted
-import platform.AVFoundation.AVCaptureDevice
-import platform.AVFoundation.AVMediaTypeVideo
-import platform.AVFoundation.authorizationStatusForMediaType
-import platform.Foundation.NSData
-import platform.Foundation.NSDocumentDirectory
-import platform.Foundation.NSError
-import platform.Foundation.NSFileHandle
-import platform.Foundation.NSFileManager
-import platform.Foundation.NSSet
-import platform.Foundation.NSString
-import platform.Foundation.NSURL
-import platform.Foundation.NSUTF8StringEncoding
-import platform.Foundation.NSUserDomainMask
-import platform.Foundation.anyObject
-import platform.Foundation.closeFile
-import platform.Foundation.create
-import platform.Foundation.fileHandleForWritingAtPath
-import platform.Foundation.seekToEndOfFile
-import platform.Foundation.stringWithContentsOfFile
-import platform.Foundation.writeData
-import platform.UIKit.UIActivityViewController
-import platform.UIKit.UIApplication
-import platform.UIKit.UIApplicationOpenSettingsURLString
-import platform.UIKit.UIViewController
-import platform.UIKit.UIWindow
-import platform.UIKit.UIWindowScene
+import platform.AVFoundation.*
+import platform.Foundation.*
+import platform.UIKit.*
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 import ui.theme.darkScheme
@@ -255,8 +214,8 @@ class IosPlatformAdapter(
         //TODO("Not yet implemented")
     }
 
-    override fun getCurrentDCAPIData(): KmmResult<DCAPIWalletRequest> {
-        return KmmResult.failure(Throwable("Using Swift platform adapter"))
+    override fun getCurrentDCAPIVerificationData(): KmmResult<RequestParametersFrom.DcApiRequest> {
+        TODO("Not yet implemented")
     }
 
     override fun prepareDCAPIIsoMdocCredentialResponse(
@@ -268,7 +227,7 @@ class IosPlatformAdapter(
     }
 
     override fun prepareDCAPIOid4vpCredentialResponse(responseJson: String, success: Boolean) {
-        //TODO("Not yet implemented")
+        // TODO("Not yet implemented")
     }
 
     override fun openDeviceSettings() {


### PR DESCRIPTION
See [EUDI TS3](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md) from 2026-03-15

Builds upon https://github.com/a-sit-plus/valera/pull/419 by rebasing it to current development

Requires https://github.com/a-sit-plus/signum/pull/433 and https://github.com/a-sit-plus/vck/pull/549 and https://github.com/a-sit-plus/vck/pull/554 and https://github.com/a-sit-plus/wallet-provider/pull/2