### PR TITLE
[codex] Refresh DC API registration after issuance

### DIFF
--- a/iosApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
+++ b/iosApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
@@ -160,6 +160,12 @@ struct DocumentProviderExtension: IdentityDocumentProvider {
         }
 
         private func setupForCurrentRequest(statefulViewController: StatefulViewController, context: Context) {
+            // The extension process is reused across DC API requests, so the cached transient
+            // session keeps a stale DataStore snapshot (DataStore is single-process and never
+            // observes the main app's cross-process writes). Close it so the session below is
+            // rebuilt with a fresh DataStore that reads newly issued credentials from disk.
+            IosSessionBridge.shared.closeTransientFlowSession()
+
             // Reset per-request state before wiring up the new request.
             context.coordinator.requestStarted = false
             context.coordinator.lastRequestSignature = buildRequestSignature(from: requestContext)

--- a/shared/src/androidMain/kotlin/main.android.kt
+++ b/shared/src/androidMain/kotlin/main.android.kt
@@ -43,7 +43,7 @@ import at.asitplus.wallet.app.common.dcapi.data.export.CredentialRegistry
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -225,8 +225,8 @@ public class AndroidPlatformAdapter(
         context.startActivity(Intent.createChooser(intent, null))
     }
 
-    override fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
-        scope.launch(Dispatchers.Default) {
+    override suspend fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
+        withContext(Dispatchers.Default) {
             catching {
                 val credentialsListCbor = coseCompliantSerializer.encodeToByteArray(entries)
                 val customRegistry = CustomRegistry(credentialsListCbor, context)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
@@ -175,6 +175,16 @@ class WalletMain(
         }
     }
 
+    suspend fun refreshDcApiCredentialRegistration() {
+        try {
+            Napier.d("DC API: Refreshing credential registration")
+            val storeContainer = subjectCredentialStore.observeStoreContainer().first()
+            dcApiExportService.registerCredentialWithSystem(storeContainer, scope)
+        } catch (e: Throwable) {
+            Napier.w("DC API: Could not refresh credentials with system", e)
+        }
+    }
+
     fun updateCheck() {
         scope.launch(Dispatchers.IO) {
             catchingUnwrapped {
@@ -258,7 +268,7 @@ interface PlatformAdapter {
      * @param entries credentials to add
      * @param scope CoroutineScope for registering credentials
      */
-    fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope)
+    suspend fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope)
 
     /**
      * Retrieves request from the digital credentials browser API
@@ -330,7 +340,7 @@ class DummyPlatformAdapter : PlatformAdapter {
     override fun shareLog() {
     }
 
-    override fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
+    override suspend fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
     }
 
     override fun getCurrentDCAPIVerificationData(): KmmResult<RequestParametersFrom.DcApiRequest> {

--- a/shared/src/commonMain/kotlin/ui/navigation/SharedFlowDestinations.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/SharedFlowDestinations.kt
@@ -404,6 +404,7 @@ internal fun NavGraphBuilder.sharedFlowDestinations(
     composable<TransientFlowIssuingResultRoute> { backStackEntry ->
         val route = backStackEntry.toRoute<TransientFlowIssuingResultRoute>()
         var isAutoDismissEnabled by rememberSaveable(route.storeEntryId) { mutableStateOf(true) }
+        var isAcknowledgeInProgress by rememberSaveable(route.storeEntryId) { mutableStateOf(false) }
         val detailsStoreEntryId = route.storeEntryId
         val storeEntry = route.storeEntryId?.let { storeEntryId ->
             walletMain.subjectCredentialStore.observeStoreContainer().map { container ->
@@ -424,11 +425,17 @@ internal fun NavGraphBuilder.sharedFlowDestinations(
             )
         }
         val onAcknowledge = {
-            if (walletMain.platformAdapter.hasPendingDCAPIIssuingRequest()) {
-                val response = flow.encodeDigitalCredentialOfferReturn(DigitalCredentialOfferReturn.success())
-                walletMain.platformAdapter.prepareDCAPIIssuingResponse(response, true)
+            if (!isAcknowledgeInProgress) {
+                isAcknowledgeInProgress = true
+                walletMain.scope.launch {
+                    walletMain.refreshDcApiCredentialRegistration()
+                    if (walletMain.platformAdapter.hasPendingDCAPIIssuingRequest()) {
+                        val response = flow.encodeDigitalCredentialOfferReturn(DigitalCredentialOfferReturn.success())
+                        walletMain.platformAdapter.prepareDCAPIIssuingResponse(response, true)
+                    }
+                    navigator.popToInvoker()
+                }
             }
-            navigator.popToInvoker()
         }
 
         val backState = rememberNavigationEventState(NavigationEventInfo.None)

--- a/shared/src/iosMain/kotlin/main.ios.kt
+++ b/shared/src/iosMain/kotlin/main.ios.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToByteArray
 import kotlin.coroutines.resume
 import kotlinx.serialization.json.Json
@@ -237,11 +238,11 @@ class IosPlatformAdapter(
         }
     }
 
-    override fun registerWithDigitalCredentialsAPI(
+    override suspend fun registerWithDigitalCredentialsAPI(
         entries: CredentialRegistry,
         scope: CoroutineScope
     ) {
-        scope.launch(Dispatchers.Default) {
+        withContext(Dispatchers.Default) {
             for (entry in entries.credentials) {
                 val id = entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
                 val docType = entry.isoEntry?.docType ?: entry.sdJwtEntry?.verifiableCredentialType
@@ -271,7 +272,7 @@ class IosPlatformAdapter(
                 if (!success) {
                     scope.launch {
                         val baseMessage = getString(Res.string.snackbar_digital_credentials_store_failed)
-                        val details = errorMessage?.toString()?.takeIf { it.isNotBlank() }
+                        val details = errorMessage.takeIf { it.isNotBlank() }
                         IosSessionBridge.showSnackbar(
                             listOfNotNull(baseMessage, details)
                                 .joinToString(": "),


### PR DESCRIPTION
## Summary
- make DC API credential registration awaitable on Android and iOS
- refresh registration immediately after successful OID4VCI and DC API issuance
- refresh before returning successful DC API issuance responses

## Root Cause
Transient and traditional issuance paths could store a credential while relying on the main-session observer to eventually update the system Digital Credentials registration. On iOS this left newly issued credentials unavailable to the IdentityDocumentProviderExtension until app restart or a later registration update.

Fixes #475

## Validation
- ./gradlew :shared:compileKotlinMetadata
- ./gradlew :shared:compileKotlinIosSimulatorArm64
- ANDROID_HOME=/Users/ckollmann/Library/Android/sdk ./gradlew :shared:compileAndroidMain
- git diff --check