### PR TITLE
[codex] Remove stale DC API registrations

### DIFF
--- a/cinterop/DigitalCredentials/DigitalCredentials.swift
+++ b/cinterop/DigitalCredentials/DigitalCredentials.swift
@@ -38,4 +38,16 @@ import IdentityDocumentServices
 
         return nil
     }
+
+    @objc public class func removeDocument(id: String) async -> String? {
+        let store = IdentityDocumentProviderRegistrationStore()
+
+        do {
+            try await store.removeRegistration(forDocumentIdentifier: id)
+        } catch {
+            return registrationErrorMessage(for: error)
+        }
+
+        return nil
+    }
 }

--- a/iosApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
+++ b/iosApp/IdentityDocumentProviderExtension/DocumentProviderExtension.swift
@@ -160,6 +160,12 @@ struct DocumentProviderExtension: IdentityDocumentProvider {
         }
 
         private func setupForCurrentRequest(statefulViewController: StatefulViewController, context: Context) {
+            // The extension process is reused across DC API requests, so the cached transient
+            // session keeps a stale DataStore snapshot (DataStore is single-process and never
+            // observes the main app's cross-process writes). Close it so the session below is
+            // rebuilt with a fresh DataStore that reads newly issued credentials from disk.
+            IosSessionBridge.shared.closeTransientFlowSession()
+
             // Reset per-request state before wiring up the new request.
             context.coordinator.requestStarted = false
             context.coordinator.lastRequestSignature = buildRequestSignature(from: requestContext)

--- a/shared/src/androidMain/kotlin/main.android.kt
+++ b/shared/src/androidMain/kotlin/main.android.kt
@@ -18,11 +18,13 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.credentials.CreateDigitalCredentialRequest
+import androidx.credentials.DigitalCredential
 import androidx.credentials.ExperimentalDigitalCredentialApi
 import androidx.credentials.GetDigitalCredentialOption
 import androidx.credentials.provider.CallingAppInfo
 import androidx.credentials.provider.PendingIntentHandler
 import androidx.credentials.provider.ProviderGetCredentialRequest
+import androidx.credentials.registry.provider.ClearCredentialRegistryRequest
 import androidx.credentials.registry.provider.RegistryManager
 import androidx.credentials.registry.provider.selectedEntryId
 import at.asitplus.KmmResult
@@ -225,12 +227,23 @@ public class AndroidPlatformAdapter(
         context.startActivity(Intent.createChooser(intent, null))
     }
 
+    @OptIn(ExperimentalDigitalCredentialApi::class)
     override suspend fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
         withContext(Dispatchers.Default) {
             catching {
                 val credentialsListCbor = coseCompliantSerializer.encodeToByteArray(entries)
                 val customRegistry = CustomRegistry(credentialsListCbor, context)
-                RegistryManager.create(context).registerCredentials(customRegistry)
+                val registryManager = RegistryManager.create(context)
+                registryManager.clearCredentialRegistry(
+                    ClearCredentialRegistryRequest(
+                        ClearCredentialRegistryRequest.PerTypeConfig(
+                            isDeleteAll = false,
+                            type = DigitalCredential.TYPE_DIGITAL_CREDENTIAL,
+                            registryIds = listOf(context.packageName),
+                        )
+                    )
+                )
+                registryManager.registerCredentials(customRegistry)
                 CustomRegistry.registerIssuance(context)
             }.onSuccess { Napier.i("DC API: Credential Manager registration succeeded") }
                 .onFailure { Napier.w("DC API: Credential Manager registration failed", it) }

--- a/shared/src/androidMain/kotlin/main.android.kt
+++ b/shared/src/androidMain/kotlin/main.android.kt
@@ -43,7 +43,7 @@ import at.asitplus.wallet.app.common.dcapi.data.export.CredentialRegistry
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -225,8 +225,8 @@ public class AndroidPlatformAdapter(
         context.startActivity(Intent.createChooser(intent, null))
     }
 
-    override fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
-        scope.launch(Dispatchers.Default) {
+    override suspend fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
+        withContext(Dispatchers.Default) {
             catching {
                 val credentialsListCbor = coseCompliantSerializer.encodeToByteArray(entries)
                 val customRegistry = CustomRegistry(credentialsListCbor, context)

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/WalletMain.kt
@@ -175,6 +175,16 @@ class WalletMain(
         }
     }
 
+    suspend fun refreshDcApiCredentialRegistration() {
+        try {
+            Napier.d("DC API: Refreshing credential registration")
+            val storeContainer = subjectCredentialStore.observeStoreContainer().first()
+            dcApiExportService.registerCredentialWithSystem(storeContainer, scope)
+        } catch (e: Throwable) {
+            Napier.w("DC API: Could not refresh credentials with system", e)
+        }
+    }
+
     fun updateCheck() {
         scope.launch(Dispatchers.IO) {
             catchingUnwrapped {
@@ -258,7 +268,7 @@ interface PlatformAdapter {
      * @param entries credentials to add
      * @param scope CoroutineScope for registering credentials
      */
-    fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope)
+    suspend fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope)
 
     /**
      * Retrieves request from the digital credentials browser API
@@ -330,7 +340,7 @@ class DummyPlatformAdapter : PlatformAdapter {
     override fun shareLog() {
     }
 
-    override fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
+    override suspend fun registerWithDigitalCredentialsAPI(entries: CredentialRegistry, scope: CoroutineScope) {
     }
 
     override fun getCurrentDCAPIVerificationData(): KmmResult<RequestParametersFrom.DcApiRequest> {

--- a/shared/src/commonMain/kotlin/ui/navigation/SharedFlowDestinations.kt
+++ b/shared/src/commonMain/kotlin/ui/navigation/SharedFlowDestinations.kt
@@ -404,6 +404,7 @@ internal fun NavGraphBuilder.sharedFlowDestinations(
     composable<TransientFlowIssuingResultRoute> { backStackEntry ->
         val route = backStackEntry.toRoute<TransientFlowIssuingResultRoute>()
         var isAutoDismissEnabled by rememberSaveable(route.storeEntryId) { mutableStateOf(true) }
+        var isAcknowledgeInProgress by rememberSaveable(route.storeEntryId) { mutableStateOf(false) }
         val detailsStoreEntryId = route.storeEntryId
         val storeEntry = route.storeEntryId?.let { storeEntryId ->
             walletMain.subjectCredentialStore.observeStoreContainer().map { container ->
@@ -424,11 +425,17 @@ internal fun NavGraphBuilder.sharedFlowDestinations(
             )
         }
         val onAcknowledge = {
-            if (walletMain.platformAdapter.hasPendingDCAPIIssuingRequest()) {
-                val response = flow.encodeDigitalCredentialOfferReturn(DigitalCredentialOfferReturn.success())
-                walletMain.platformAdapter.prepareDCAPIIssuingResponse(response, true)
+            if (!isAcknowledgeInProgress) {
+                isAcknowledgeInProgress = true
+                walletMain.scope.launch {
+                    walletMain.refreshDcApiCredentialRegistration()
+                    if (walletMain.platformAdapter.hasPendingDCAPIIssuingRequest()) {
+                        val response = flow.encodeDigitalCredentialOfferReturn(DigitalCredentialOfferReturn.success())
+                        walletMain.platformAdapter.prepareDCAPIIssuingResponse(response, true)
+                    }
+                    navigator.popToInvoker()
+                }
             }
-            navigator.popToInvoker()
         }
 
         val backState = rememberNavigationEventState(NavigationEventInfo.None)

--- a/shared/src/iosMain/kotlin/main.ios.kt
+++ b/shared/src/iosMain/kotlin/main.ios.kt
@@ -27,12 +27,12 @@ import at.asitplus.wallet.app.ios.DigitalCredentials
 import at.asitplus.wallet.eupid.EU_PID_DOCTYPE
 import at.asitplus.wallet.mdl.MDL_DOCTYPE
 import kotlinx.cinterop.*
-import kotlinx.atomicfu.locks.SynchronizedObject
-import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToByteArray
 import kotlin.coroutines.resume
@@ -102,7 +102,7 @@ class IosPlatformAdapter(
 ) : PlatformAdapter {
     private companion object {
         const val REGISTERED_DOCUMENT_IDS_DEFAULTS_KEY = "dcapi.registeredDocumentIds"
-        val registeredDocumentIdsLock = SynchronizedObject()
+        val registeredDocumentIdsLock = Mutex()
         val registeredDocumentIds = mutableSetOf<String>().apply {
             addAll(loadRegisteredDocumentIds())
         }
@@ -267,26 +267,24 @@ class IosPlatformAdapter(
         scope: CoroutineScope
     ) {
         withContext(Dispatchers.Default) {
-            val currentIds = entries.credentials.mapNotNull { entry ->
-                entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
-            }.toSet()
-            val staleIds = synchronized(registeredDocumentIdsLock) {
-                registeredDocumentIds - currentIds
-            }
-            staleIds.forEach { id ->
-                if (removeDocumentFromSwift(id, scope)) {
-                    synchronized(registeredDocumentIdsLock) {
+            // Serialize the whole removal+add process so concurrent snapshots can't interleave.
+            registeredDocumentIdsLock.withLock {
+                val currentIds = entries.credentials.mapNotNull { entry ->
+                    entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
+                }.toSet()
+                val staleIds = registeredDocumentIds - currentIds
+                staleIds.forEach { id ->
+                    if (removeDocumentFromSwift(id, scope)) {
                         registeredDocumentIds.remove(id)
                         saveRegisteredDocumentIds(registeredDocumentIds)
                     }
                 }
-            }
-            for (entry in entries.credentials) {
-                val id = entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
-                val docType = entry.isoEntry?.docType ?: entry.sdJwtEntry?.verifiableCredentialType
-                if (id != null && docType != null) {
-                    if (storeDocumentFromSwift(id, docType, scope)) {
-                        synchronized(registeredDocumentIdsLock) {
+                for (entry in entries.credentials) {
+                    val id = entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
+                    val docType = entry.isoEntry?.docType ?: entry.sdJwtEntry?.verifiableCredentialType
+                    // Only register credentials we haven't registered before.
+                    if (id != null && docType != null && id !in registeredDocumentIds) {
+                        if (storeDocumentFromSwift(id, docType, scope)) {
                             registeredDocumentIds.add(id)
                             saveRegisteredDocumentIds(registeredDocumentIds)
                         }

--- a/shared/src/iosMain/kotlin/main.ios.kt
+++ b/shared/src/iosMain/kotlin/main.ios.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToByteArray
 import kotlin.coroutines.resume
 import kotlinx.serialization.json.Json
@@ -237,11 +238,11 @@ class IosPlatformAdapter(
         }
     }
 
-    override fun registerWithDigitalCredentialsAPI(
+    override suspend fun registerWithDigitalCredentialsAPI(
         entries: CredentialRegistry,
         scope: CoroutineScope
     ) {
-        scope.launch(Dispatchers.Default) {
+        withContext(Dispatchers.Default) {
             for (entry in entries.credentials) {
                 val id = entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
                 val docType = entry.isoEntry?.docType ?: entry.sdJwtEntry?.verifiableCredentialType
@@ -271,7 +272,7 @@ class IosPlatformAdapter(
                 if (!success) {
                     scope.launch {
                         val baseMessage = getString(Res.string.snackbar_digital_credentials_store_failed)
-                        val details = errorMessage?.toString()?.takeIf { it.isNotBlank() }
+                        val details = errorMessage.takeIf { it.isNotBlank() }
                         IosSessionBridge.showSnackbar(
                             listOfNotNull(baseMessage, details)
                                 .joinToString(": "),

--- a/shared/src/iosMain/kotlin/main.ios.kt
+++ b/shared/src/iosMain/kotlin/main.ios.kt
@@ -27,6 +27,8 @@ import at.asitplus.wallet.app.ios.DigitalCredentials
 import at.asitplus.wallet.eupid.EU_PID_DOCTYPE
 import at.asitplus.wallet.mdl.MDL_DOCTYPE
 import kotlinx.cinterop.*
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -98,6 +100,28 @@ fun TransientFlowMainViewController(
 class IosPlatformAdapter(
     private val intentState: IntentState
 ) : PlatformAdapter {
+    private companion object {
+        const val REGISTERED_DOCUMENT_IDS_DEFAULTS_KEY = "dcapi.registeredDocumentIds"
+        val registeredDocumentIdsLock = SynchronizedObject()
+        val registeredDocumentIds = mutableSetOf<String>().apply {
+            addAll(loadRegisteredDocumentIds())
+        }
+
+        fun loadRegisteredDocumentIds(): Set<String> =
+            NSUserDefaults.standardUserDefaults
+                .stringArrayForKey(REGISTERED_DOCUMENT_IDS_DEFAULTS_KEY)
+                ?.filterIsInstance<String>()
+                ?.toSet()
+                ?: emptySet()
+
+        fun saveRegisteredDocumentIds(ids: Set<String>) {
+            NSUserDefaults.standardUserDefaults.setObject(
+                ids.toList(),
+                forKey = REGISTERED_DOCUMENT_IDS_DEFAULTS_KEY
+            )
+        }
+    }
+
     override fun openUrl(url: String) {
         dispatch_async(dispatch_get_main_queue()) {
             val url = NSURL(string = url)
@@ -243,11 +267,30 @@ class IosPlatformAdapter(
         scope: CoroutineScope
     ) {
         withContext(Dispatchers.Default) {
+            val currentIds = entries.credentials.mapNotNull { entry ->
+                entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
+            }.toSet()
+            val staleIds = synchronized(registeredDocumentIdsLock) {
+                registeredDocumentIds - currentIds
+            }
+            staleIds.forEach { id ->
+                if (removeDocumentFromSwift(id, scope)) {
+                    synchronized(registeredDocumentIdsLock) {
+                        registeredDocumentIds.remove(id)
+                        saveRegisteredDocumentIds(registeredDocumentIds)
+                    }
+                }
+            }
             for (entry in entries.credentials) {
                 val id = entry.isoEntry?.id ?: entry.sdJwtEntry?.jwtId
                 val docType = entry.isoEntry?.docType ?: entry.sdJwtEntry?.verifiableCredentialType
                 if (id != null && docType != null) {
-                    storeDocumentFromSwift(id, docType, scope)
+                    if (storeDocumentFromSwift(id, docType, scope)) {
+                        synchronized(registeredDocumentIdsLock) {
+                            registeredDocumentIds.add(id)
+                            saveRegisteredDocumentIds(registeredDocumentIds)
+                        }
+                    }
                 }
             }
         }
@@ -283,6 +326,33 @@ class IosPlatformAdapter(
                 if (cont.isActive) cont.resume(success)
             }
             Napier.d("storeDocumentFromSwift got back from swift")
+        } catch (e: Throwable) {
+            Napier.e("Error while invoking Swift code", e)
+            if (cont.isActive) cont.resume(false)
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private suspend fun removeDocumentFromSwift(
+        id: String,
+        scope: CoroutineScope
+    ): Boolean = suspendCancellableCoroutine { cont ->
+        try {
+            Napier.d("removeDocumentFromSwift invoked")
+            DigitalCredentials.removeDocumentWithId(id) { errorMessage ->
+                val success = errorMessage == null
+                Napier.d("removeDocumentFromSwift callback with success=$success error=$errorMessage")
+                if (!success) {
+                    scope.launch {
+                        IosSessionBridge.showSnackbar(
+                            errorMessage.takeUnless { it.isNullOrBlank() } ?: "Unable to remove stale document registration",
+                            SnackbarDuration.Long
+                        )
+                    }
+                }
+                if (cont.isActive) cont.resume(success)
+            }
+            Napier.d("removeDocumentFromSwift got back from swift")
         } catch (e: Throwable) {
             Napier.e("Error while invoking Swift code", e)
             if (cont.isActive) cont.resume(false)


### PR DESCRIPTION
## Summary
- remove stale iOS IdentityDocumentProvider registrations when credentials disappear from the wallet snapshot
- persist the iOS registered document ID set so stale registrations can be cleaned across launches
- clear the Android presentation registry before registering the latest full credential snapshot

## Notes
This is stacked on top of #483 / `codex/fix-dcapi-registration-refresh-475` so it can reuse the awaitable DC API registration path introduced there.

Credential deletion already emits a new credential-store snapshot through `removeStoreEntryById(...)`; the existing DC API registration observer receives that snapshot and now removes stale platform registrations as part of the registration update.

Fixes #473

## Validation
- ./gradlew :shared:compileKotlinIosSimulatorArm64
- ANDROID_HOME=/Users/ckollmann/Library/Android/sdk ./gradlew :shared:compileAndroidMain
- git diff --check