### PR TITLE
UI: Resolve credential schemes for all labels

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/Extensions.kt
@@ -54,7 +54,10 @@ import org.jetbrains.compose.resources.stringResource
 import ui.presentation.DCQLCredentialQueryUiModel
 import ui.presentation.DCQLCredentialQueryUiModelAttributeLabels
 
-fun InputDescriptor.extractConsentData(): Triple<CredentialRepresentation, CredentialScheme, Map<NormalizedJsonPath, Boolean>> {
+typealias PresentationExchangeConsentData = Triple<CredentialRepresentation, CredentialScheme, Map<NormalizedJsonPath, Boolean>>
+typealias DcqlConsentData = Triple<CredentialRepresentation, CredentialScheme, Collection<SingleClaimReference?>?>
+
+suspend fun InputDescriptor.extractConsentData(): PresentationExchangeConsentData {
     @Suppress("DEPRECATION")
     val credentialRepresentation = when {
         this.format == null -> throw IllegalStateException("Format of input descriptor must be set")
@@ -71,14 +74,7 @@ fun InputDescriptor.extractConsentData(): Triple<CredentialRepresentation, Crede
         "Presentation definition input descriptor '$id' does not declare any credential identifier"
     }
 
-    // TODO: How to properly handle the case with multiple applicable schemes?
-    val scheme = AttributeIndex.schemeSet.firstOrNull {
-        it.matchAgainstIdentifier(credentialRepresentation, credentialIdentifiers)
-    } ?: when (credentialRepresentation) {
-        PLAIN_JWT -> VcFallbackCredentialScheme(vcType = credentialIdentifiers.first())
-        SD_JWT -> SdJwtFallbackCredentialScheme(sdJwtType = credentialIdentifiers.first())
-        ISO_MDOC -> IsoMdocFallbackCredentialScheme(isoDocType = credentialIdentifiers.first())
-    }
+    val scheme = resolveConsentScheme(credentialRepresentation, credentialIdentifiers)
 
     val matchedCredentialIdentifier = when (credentialRepresentation) {
         PLAIN_JWT -> throw Throwable("PLAIN_JWT not implemented")
@@ -108,14 +104,24 @@ fun InputDescriptor.extractConsentData(): Triple<CredentialRepresentation, Crede
     return Triple(credentialRepresentation, scheme, attributes)
 }
 
-private fun CredentialScheme.matchAgainstIdentifier(
+/**
+ * Resolves the first identifier yielding a scheme with known type metadata, triggering (cached)
+ * remote type-metadata retrieval where needed. Unlike a lookup in [AttributeIndex.schemeSet],
+ * this also works in a freshly started process whose in-memory scheme index is still cold
+ * (e.g. the iOS identity provider extension answering a DC API request).
+ */
+private suspend fun resolveConsentScheme(
     representation: CredentialRepresentation,
-    identifiers: Collection<String>
-) = when (representation) {
-    PLAIN_JWT -> throw Throwable("PLAIN_JWT not implemented")
-    SD_JWT -> sdJwtType in identifiers
-    ISO_MDOC -> isoDocType in identifiers
+    identifiers: Collection<String>,
+): CredentialScheme {
+    require(identifiers.isNotEmpty()) { "No credential identifier to resolve a scheme from" }
+    val schemes = identifiers.map { AttributeIndex.resolveIdentifier(it, representation) }
+    return schemes.firstOrNull { !it.isFallback() } ?: schemes.first()
 }
+
+private fun CredentialScheme.isFallback() = this is VcFallbackCredentialScheme
+        || this is SdJwtFallbackCredentialScheme
+        || this is IsoMdocFallbackCredentialScheme
 
 private fun InputDescriptor.vctConstraint() =
     constraints?.fields?.firstOrNull { it.path.toString().contains("vct") }
@@ -127,7 +133,7 @@ private fun ConstraintFilter.referenceValues() =
  * assumes json claim path pointers don't contain `null`, otherwise only the prefix is shown
  */
 @Throws(Throwable::class)
-fun DCQLCredentialQuery.extractConsentData(): Triple<CredentialRepresentation, CredentialScheme, Collection<SingleClaimReference?>?> {
+suspend fun DCQLCredentialQuery.extractConsentData(): DcqlConsentData {
     val representation = when (format) {
         CredentialFormatEnum.DC_SD_JWT -> SD_JWT
         CredentialFormatEnum.MSO_MDOC -> ISO_MDOC
@@ -135,24 +141,15 @@ fun DCQLCredentialQuery.extractConsentData(): Triple<CredentialRepresentation, C
     }
 
     val scheme = when (this) {
-        is DCQLIsoMdocCredentialQuery -> meta.doctypeValue
-            .let { AttributeIndex.resolveIsoDoctype(it) }
+        is DCQLIsoMdocCredentialQuery -> resolveConsentScheme(ISO_MDOC, listOf(meta.doctypeValue))
 
-        is DCQLSdJwtCredentialQuery -> meta.vctValues
-            .firstNotNullOfOrNull { AttributeIndex.resolveSdJwtAttributeType(it) }
+        is DCQLSdJwtCredentialQuery -> resolveConsentScheme(SD_JWT, meta.vctValues)
 
-        is DCQLJwtVcCredentialQuery -> meta.typeValues.list.flatten()
-            .filterNot { it == VERIFIABLE_CREDENTIAL }
-            .firstNotNullOfOrNull { AttributeIndex.resolveAttributeType(it) }
-    } ?: when (this) {
-        is DCQLIsoMdocCredentialQuery -> IsoMdocFallbackCredentialScheme(isoDocType = meta.doctypeValue)
-        is DCQLSdJwtCredentialQuery -> meta.vctValues
-            .firstNotNullOfOrNull { SdJwtFallbackCredentialScheme(sdJwtType = it) }
-
-        is DCQLJwtVcCredentialQuery -> meta.typeValues.list.flatten()
-            .filterNot { it == VERIFIABLE_CREDENTIAL }
-            .firstNotNullOfOrNull { VcFallbackCredentialScheme(vcType = it) }
-    } ?: throw Throwable("No matching scheme for $meta")
+        is DCQLJwtVcCredentialQuery -> resolveConsentScheme(
+            PLAIN_JWT,
+            meta.typeValues.list.flatten().filterNot { it == VERIFIABLE_CREDENTIAL },
+        )
+    }
 
     // assuming all claims path pointers are single claim references
     val singleReferenceClaimsQueries = this.claims?.associateWith {

--- a/shared/src/commonMain/kotlin/ui/composables/PresentationRequestPreview.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/PresentationRequestPreview.kt
@@ -3,6 +3,8 @@ package ui.composables
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import at.asitplus.catchingUnwrapped
@@ -12,6 +14,8 @@ import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.valera.resources.Res
 import at.asitplus.valera.resources.error_complex_dcql_query
 import at.asitplus.valera.resources.error_invalid_dcql_query
+import at.asitplus.wallet.app.common.DcqlConsentData
+import at.asitplus.wallet.app.common.PresentationExchangeConsentData
 import at.asitplus.wallet.app.common.extractConsentData
 import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.data.getLocalization
 import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.data.uiLabel
@@ -53,19 +57,23 @@ fun InputDescriptorPreview(
     inputDescriptors: List<InputDescriptor>,
     onError: (Throwable) -> Unit,
 ) {
-    inputDescriptors.forEach { inputDescriptor ->
-        catchingUnwrapped {
-            inputDescriptor.extractConsentData()
-        }.onSuccess { (representation, scheme, attributes) ->
-            RequestedCredentialPreview(
-                scheme = scheme,
-                representation = representation,
-                attributes = attributes.mapKeys { it.key }
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-        }.onFailure {
-            onError(it)
+    // Resolved in a coroutine: scheme resolution may fetch type metadata (from the persistent
+    // cache or remotely) when the in-memory scheme index is still cold, e.g. right after the
+    // iOS identity provider extension process started for a DC API request.
+    val consentData by produceState<List<PresentationExchangeConsentData>?>(null, inputDescriptors) {
+        value = inputDescriptors.mapNotNull { inputDescriptor ->
+            catchingUnwrapped { inputDescriptor.extractConsentData() }
+                .onFailure(onError)
+                .getOrNull()
         }
+    }
+    consentData?.forEach { (representation, scheme, attributes) ->
+        RequestedCredentialPreview(
+            scheme = scheme,
+            representation = representation,
+            attributes = attributes.mapKeys { it.key }
+        )
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }
 
@@ -84,20 +92,20 @@ fun DcqlRequestPreview(
     }
     val requestedCredentialCombination = credentialSetQuery.options.first()
 
-    requestedCredentialCombination.forEach { credentialQueryIdentifier ->
-        val credentialQuery = presentationRequest.dcqlQuery.credentials.find {
-            it.id == credentialQueryIdentifier
-        }
-        if (credentialQuery == null) {
-            return onError(IllegalArgumentException(stringResource(Res.string.error_invalid_dcql_query)))
-        }
+    val invalidQueryMessage = stringResource(Res.string.error_invalid_dcql_query)
+    // Resolved in a coroutine: see InputDescriptorPreview.
+    val consentData by produceState<List<DcqlConsentData>?>(null, presentationRequest) {
+        value = catchingUnwrapped {
+            requestedCredentialCombination.map { credentialQueryIdentifier ->
+                val credentialQuery = presentationRequest.dcqlQuery.credentials.find {
+                    it.id == credentialQueryIdentifier
+                } ?: throw IllegalArgumentException(invalidQueryMessage)
+                credentialQuery.extractConsentData()
+            }
+        }.onFailure(onError).getOrNull()
+    }
 
-        val (representation, scheme, attributePaths) = try {
-            credentialQuery.extractConsentData()
-        } catch (e: Throwable) {
-            return onError(e)
-        }
-
+    consentData?.forEach { (representation, scheme, attributePaths) ->
         RequestedCredentialPreview(
             scheme = scheme,
             representation = representation,

--- a/shared/src/commonMain/kotlin/ui/presentation/AuthenticationReceivedStartPageContent.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/AuthenticationReceivedStartPageContent.kt
@@ -13,7 +13,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
@@ -27,6 +28,8 @@ import at.asitplus.valera.resources.heading_label_authenticate_at_device_screen
 import at.asitplus.valera.resources.heading_label_show_data_third_party
 import at.asitplus.valera.resources.prompt_send_above_data
 import at.asitplus.valera.resources.section_heading_data_recipient
+import at.asitplus.catchingUnwrapped
+import at.asitplus.wallet.app.common.DcqlConsentData
 import at.asitplus.wallet.app.common.extractConsentData
 import at.asitplus.wallet.app.common.toCredentialQueryUiModel
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
@@ -101,15 +104,15 @@ fun AuthenticationReceivedStartPageContent(
                         is CredentialPresentationRequest.DCQLRequest -> Column(
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            presentationRequest.dcqlQuery.credentials.associate {
-                                it.id to try { // TODO: improve on this by storing it somewhere?
-                                    it.extractConsentData()
-                                } catch (e: Throwable) {
-                                    return@Box LaunchedEffect(Unit) {
-                                        onError(e)
-                                    }
-                                }.toCredentialQueryUiModel()
-                            }.forEach { (_, credentialQueryUiModel) ->
+                            // Resolved in a coroutine: scheme resolution may fetch type metadata
+                            // when the in-memory scheme index is still cold (fresh process).
+                            val consentData by produceState<List<DcqlConsentData>?>(null, presentationRequest) {
+                                value = catchingUnwrapped {
+                                    presentationRequest.dcqlQuery.credentials.map { it.extractConsentData() }
+                                }.onFailure(onError).getOrNull()
+                            }
+                            consentData?.forEach { data ->
+                                val credentialQueryUiModel = data.toCredentialQueryUiModel()
                                 CredentialSetQueryOptionSelectionCard(
                                     credentialRepresentationLocalized = credentialQueryUiModel.credentialRepresentationLocalized,
                                     credentialSchemeLocalized = credentialQueryUiModel.credentialSchemeLocalized,

--- a/shared/src/commonMain/kotlin/ui/presentation/DCQLPresentationBuilderGraphViewContent.kt
+++ b/shared/src/commonMain/kotlin/ui/presentation/DCQLPresentationBuilderGraphViewContent.kt
@@ -5,10 +5,14 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
+import at.asitplus.catchingUnwrapped
 import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.openid.dcql.DCQLQuery
+import at.asitplus.wallet.app.common.DcqlConsentData
 import at.asitplus.wallet.app.common.extractConsentData
 import at.asitplus.wallet.app.common.toCredentialQueryUiModel
 
@@ -82,15 +86,16 @@ fun DCQLPresentationBuilderGraphViewContent(
         } ?: listOf()
     }.flatten()
 
-    val credentialQueryUiModels = dcqlQuery.credentials.associate {
-        it.id to try { // TODO: improve on this by storing it somewhere?
-            it.extractConsentData()
-        } catch (e: Throwable) {
-            return LaunchedEffect(Unit) {
-                onError(e)
-            }
-        }.toCredentialQueryUiModel()
+    // Resolved in a coroutine: scheme resolution may fetch type metadata when the in-memory
+    // scheme index is still cold (fresh process); the progress indicator above bridges the gap.
+    val consentData by produceState<Map<DCQLCredentialQueryIdentifier, DcqlConsentData>?>(null, dcqlQuery) {
+        value = catchingUnwrapped {
+            dcqlQuery.credentials.associate { it.id to it.extractConsentData() }
+        }.onFailure(onError).getOrNull()
     }
+    val credentialQueryUiModels = consentData?.mapValues {
+        it.value.toCredentialQueryUiModel()
+    } ?: return
 
     requestedCredentialQueries.firstOrNull {
         confirmedSubmissionIndices[it]?.isEmpty() ?: true

--- a/shared/src/commonTest/kotlin/at/asitplus/wallet/app/common/ConsentDataResolutionTest.kt
+++ b/shared/src/commonTest/kotlin/at/asitplus/wallet/app/common/ConsentDataResolutionTest.kt
@@ -1,0 +1,157 @@
+package at.asitplus.wallet.app.common
+
+import at.asitplus.dif.Constraint
+import at.asitplus.dif.ConstraintField
+import at.asitplus.dif.DifInputDescriptor
+import at.asitplus.dif.FormatContainerJwt
+import at.asitplus.dif.FormatHolder
+import at.asitplus.jsonpath.core.NormalizedJsonPath
+import at.asitplus.jsonpath.core.NormalizedJsonPathSegment.NameSegment
+import at.asitplus.openid.dcql.DCQLClaimsPathPointer
+import at.asitplus.openid.dcql.DCQLClaimsQueryList
+import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
+import at.asitplus.openid.dcql.DCQLJsonClaimsQuery
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.data.getLocalization
+import at.asitplus.wallet.lib.LibraryInitializer
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import at.asitplus.wallet.lib.data.CredentialMetadataRegistry
+import at.asitplus.wallet.lib.data.ResolvedCredentialMetadata
+import at.asitplus.wallet.sdjwt.SdJwtTypeMetadataDefinition
+import at.asitplus.wallet.sdjwt.SdJwtTypeMetadataDocument
+import at.asitplus.wallet.sdjwt.SdJwtTypeMetadataVckExtensions
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import at.asitplus.openid.CredentialFormatEnum as OpenIdCredentialFormatEnum
+import at.asitplus.wallet.sdjwt.CredentialFormatEnum as SdJwtCredentialFormatEnum
+
+/**
+ * The consent screen must resolve claim labels from type metadata even in a freshly started
+ * process whose in-memory scheme index is still cold, e.g. the iOS identity provider extension
+ * answering a DC API request: scheme resolution has to go through the (suspending) credential
+ * metadata registry instead of only looking at already-registered schemes.
+ */
+class ConsentDataResolutionTest {
+
+    /** Input descriptors like those built from the iOS DC API mdoc pre-request summary. */
+    @Test
+    fun resolvesMdocClaimLabelsThroughMetadataRegistry() = runTest {
+        registerTestMetadata()
+        val descriptor = DifInputDescriptor(
+            id = TEST_DOCTYPE,
+            format = FormatHolder(msoMdoc = FormatContainerJwt()),
+            constraints = Constraint(
+                fields = setOf(
+                    ConstraintField(
+                        path = listOf(
+                            NormalizedJsonPath(
+                                NameSegment(TEST_NAMESPACE),
+                                NameSegment("family_name"),
+                            ).toString()
+                        ),
+                    )
+                )
+            ),
+        )
+
+        val (representation, scheme, attributes) = descriptor.extractConsentData()
+
+        assertEquals(ISO_MDOC, representation)
+        assertEquals(TEST_LABEL, scheme.getLocalization(attributes.keys.single()))
+    }
+
+    /** A DCQL query like an Android DC API / OpenID4VP request for an SD-JWT credential. */
+    @Test
+    fun resolvesSdJwtClaimLabelsThroughMetadataRegistry() = runTest {
+        registerTestMetadata()
+        val query = DCQLSdJwtCredentialQuery(
+            id = DCQLCredentialQueryIdentifier("query"),
+            format = OpenIdCredentialFormatEnum.DC_SD_JWT,
+            meta = DCQLSdJwtCredentialMetadataAndValidityConstraints(vctValues = listOf(TEST_VCT)),
+            claims = DCQLClaimsQueryList(DCQLJsonClaimsQuery(path = DCQLClaimsPathPointer("family_name"))),
+        )
+
+        val (representation, scheme, claimReferences) = query.extractConsentData()
+
+        assertEquals(SD_JWT, representation)
+        val reference = assertNotNull(assertNotNull(claimReferences).filterNotNull().single())
+        assertEquals(TEST_LABEL, scheme.getLocalization(reference))
+    }
+
+    companion object {
+        private const val TEST_VCT = "urn:example:valera:consent-test"
+        private const val TEST_DOCTYPE = "org.example.valera.consent-test"
+        private const val TEST_NAMESPACE = "org.example.valera.consent-test.ns"
+        private const val TEST_LABEL = "Family name test"
+
+        private var registered = false
+
+        private fun registerTestMetadata() {
+            if (registered) return
+            registered = true
+            LibraryInitializer.registerCredentialMetadataRegistry(
+                TestMetadataRegistry(
+                    mapOf(
+                        (TEST_DOCTYPE to ISO_MDOC) to resolvedMetadata(
+                            vct = TEST_DOCTYPE,
+                            claimPath = listOf(TEST_NAMESPACE, "family_name"),
+                            vckExtensions = SdJwtTypeMetadataVckExtensions(
+                                format = SdJwtCredentialFormatEnum.MSO_MDOC,
+                                isoDocType = TEST_DOCTYPE,
+                                isoNamespace = TEST_NAMESPACE,
+                            ),
+                        ),
+                        (TEST_VCT to SD_JWT) to resolvedMetadata(
+                            vct = TEST_VCT,
+                            claimPath = listOf("family_name"),
+                        ),
+                    )
+                )
+            )
+        }
+
+        private fun resolvedMetadata(
+            vct: String,
+            claimPath: List<String>,
+            vckExtensions: SdJwtTypeMetadataVckExtensions? = null,
+        ): ResolvedCredentialMetadata {
+            val decoded = joseCompliantSerializer.decodeFromString(
+                SdJwtTypeMetadataDocument.serializer(),
+                """
+                {
+                  "vct": "$vct",
+                  "name": "Consent test credential",
+                  "claims": [
+                    {
+                      "path": [${claimPath.joinToString(",") { "\"$it\"" }}],
+                      "display": [{ "locale": "en", "label": "$TEST_LABEL" }]
+                    }
+                  ]
+                }
+                """.trimIndent()
+            ).definition
+            return ResolvedCredentialMetadata(
+                metadata = SdJwtTypeMetadataDefinition(
+                    vct = decoded.vct,
+                    claims = decoded.claims,
+                    vckExtensions = vckExtensions,
+                ).toSdJwtTypeMetadata(),
+                loadedFrom = "https://metadata.example.test/consent-test.json",
+            )
+        }
+    }
+
+    /** Resolves on demand only, like a remote registry: nothing is pre-seeded into the synchronous scheme index. */
+    private class TestMetadataRegistry(
+        private val entries: Map<Pair<String, CredentialRepresentation>, ResolvedCredentialMetadata>,
+    ) : CredentialMetadataRegistry {
+        override suspend fun findEntry(identifier: String, representation: CredentialRepresentation) =
+            entries[identifier to representation]
+    }
+}


### PR DESCRIPTION
Fixes the issue that the iOS extension for handling DCAPI requests did not resolve credential schemes, leading to untranslated claim names in the consent screen.