### PR TITLE
Release 5.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Release 5.8.1 (unreleased):
- * Update to VC-K 7.0.0-SNAPSHOT
+ * Update to VC-K 7.0.0
  * Rework resolving credential schemes
  * Drop support for PID in VC JWT (which was never officially specified anyway)
- * Update DCAPI matching implementation for Android
+ * DCAPI: Update matching implementation, improve iOS state handling
  * Fix opening second provisioning flow after aborting the first one
  * Add `TrustListService` for loading LoTE regularly in the background
- * Display trust evaluation in Consent Screen and in `CredentialsDetailsView`
+ * Display trust evaluation of credentials
+ * Cache remote lookups of trust lists and status lists
+ * Improve dark theme
+ * Improve UI performance
 
 # Release 5.8.0
  * Update to VC-K 6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 5.8.1 (unreleased):
+# Release 5.8.1:
  * Update to VC-K 7.0.0
  * Rework resolving credential schemes
  * Drop support for PID in VC JWT (which was never officially specified anyway)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #versioning
 version.code=50801
-version.name=5.8.1-SNAPSHOT
+version.name=5.8.1
 
 #Gradle
 org.gradle.jvmargs=-Xmx8192M -Dkotlin.daemon.jvm.options\="-Xmx8192M"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-vck="7.0.0-SNAPSHOT"
+vck="7.0.0"
 
 agp = "8.12.3"
 kotlin = "2.3.0"

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -204,7 +204,6 @@
     <string name="prompt_select_credential">Welches Credential soll verwendet werden?</string>
     <string name="prompt_select_attribute">Welche Attribute sollen übermittelt werden?</string>
 
-    <string name="error_credential_matching_failed">UNPASSEND</string>
     <string name="error_credential_status_invalid">UNGÜLTIG</string>
     <string name="error_credential_timeliness_expired">ABGELAUFEN</string>
     <string name="error_credential_timeliness_not_yet_valid">NOCH NICHT GÜLTIG</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -437,7 +437,7 @@
     <string name="button_dismiss">Verwerfen</string>
     <string name="button_remove">Entfernen</string>
     <string name="button_refresh">Aktualisieren</string>
-    <string name="refresh_snackbar_message_single">Aktualisierung verfügbar für \'%1$s\'</string>
+    <string name="refresh_snackbar_message_single">Aktualisierung verfügbar für '%1$s'</string>
     <string name="refresh_snackbar_message_multiple">Aktualisierungen für mehrere Ausweise verfügbar</string>
     <string name="refresh_snackbar_action">Jetzt aktualisieren</string>
     <string name="error_no_refresh_token">Kein Refresh-Token verfügbar</string>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -210,7 +210,6 @@
     <string name="prompt_select_credential">Which Credential should be used?</string>
     <string name="prompt_select_attribute">Which attributes should be transmitted?</string>
 
-    <string name="error_credential_matching_failed">UNSUITABLE</string>
     <string name="error_credential_status_invalid">INVALID</string>
     <string name="error_credential_timeliness_expired">EXPIRED</string>
     <string name="error_credential_timeliness_not_yet_valid">NOT YET VALID</string>

--- a/shared/src/commonMain/composeResources/values-en/strings.xml
+++ b/shared/src/commonMain/composeResources/values-en/strings.xml
@@ -430,7 +430,7 @@
     <string name="button_dismiss">Dismiss</string>
     <string name="button_remove">Remove</string>
     <string name="button_refresh">Refresh</string>
-    <string name="refresh_snackbar_message_single">Update available for \'%1$s\'</string>
+    <string name="refresh_snackbar_message_single">Update available for '%1$s'</string>
     <string name="refresh_snackbar_message_multiple">Updates available for multiple credentials</string>
     <string name="refresh_snackbar_action">Update Now</string>
     <string name="error_no_refresh_token">No refresh token available</string>

--- a/shared/src/commonMain/kotlin/ui/composables/IssuerTrustDetailsCard.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/IssuerTrustDetailsCard.kt
@@ -41,7 +41,7 @@ fun IssuerTrustDetailsCard(
     val rdnAttributes = certificate.tbsCertificate.subjectName.flatMap { it.attrsAndValues }
     val issuerName = rdnAttributes.firstOrNull { it is AttributeTypeAndValue.Organization }?.value?.asPrimitive()?.decodeToString()
         ?: rdnAttributes.firstOrNull { it is AttributeTypeAndValue.CommonName }?.value?.asPrimitive()?.decodeToString()
-        ?: "Unknown Issuer"
+        ?: certificate.tbsCertificate.subjectName.toString()
 
     val validFrom = certificate.tbsCertificate.validFrom.instant.toString()
     val validUntil = certificate.tbsCertificate.validUntil.instant.toString()

--- a/shared/src/commonMain/kotlin/ui/composables/IssuerTrustDetailsCard.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/IssuerTrustDetailsCard.kt
@@ -1,45 +1,21 @@
 package ui.composables
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowDownward
-import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import at.asitplus.signum.indispensable.Digest
-import at.asitplus.signum.indispensable.X509SignatureAlgorithm
 import at.asitplus.signum.indispensable.asn1.encoding.decodeToString
 import at.asitplus.signum.indispensable.pki.AttributeTypeAndValue
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.signum.indispensable.requireSupported
 import at.asitplus.signum.supreme.hash.digest
 import at.asitplus.valera.resources.Res
-import at.asitplus.valera.resources.button_label_hide_technical_details
-import at.asitplus.valera.resources.button_label_show_technical_details
 import at.asitplus.valera.resources.section_heading_issuer_trust
 import at.asitplus.valera.resources.section_heading_issuer_trust_icon_text
 import at.asitplus.valera.resources.text_label_issued_by
@@ -60,7 +36,6 @@ fun IssuerTrustDetailsCard(
     trustState: TrustState,
     modifier: Modifier = Modifier
 ) {
-    var showTechnicalDetails by remember { mutableStateOf(false) }
     val contentPadding = Modifier.padding(bottom = 16.dp, end = 16.dp, start = 16.dp)
 
     val rdnAttributes = certificate.tbsCertificate.subjectName.flatMap { it.attrsAndValues }
@@ -72,7 +47,10 @@ fun IssuerTrustDetailsCard(
     val validUntil = certificate.tbsCertificate.validUntil.instant.toString()
     val digest = certificate.signatureAlgorithm.let {
         it.requireSupported()
-        it.digest.digest(certificate.encodeToDer()).contentToString()
+        it.digest.digest(certificate.encodeToDer())
+            .toHexString(HexFormat.UpperCase)
+            .chunked(2)
+            .joinToString(":")
     }
     val displayTrust = when (trustState) {
         TrustState.TRUSTED -> stringResource(Res.string.trust_status_trusted)
@@ -81,108 +59,60 @@ fun IssuerTrustDetailsCard(
         TrustState.EVALUATING -> stringResource(Res.string.trust_status_evaluating)
     }
 
-    Column(modifier = modifier) {
-        ElevatedCard(modifier = Modifier.padding(bottom = 16.dp)) {
-            Column(modifier = Modifier.fillMaxWidth()) {
-                PersonAttributeDetailCardHeading(
-                    iconText = stringResource(Res.string.section_heading_issuer_trust_icon_text),
-                    title = stringResource(Res.string.section_heading_issuer_trust),
-                )
-
-                LabeledText(
-                    label = stringResource(Res.string.text_label_issued_by),
-                    text = issuerName,
-                    modifier = contentPadding,
-                    fontWeight = FontWeight.Normal
-                )
-
-                LabeledText(
-                    label = stringResource(Res.string.text_label_trust_status),
-                    text = displayTrust,
-                    modifier = contentPadding,
-                    fontWeight = FontWeight.Normal
-                )
-
-                val density = LocalDensity.current
-                AnimatedVisibility(
-                    visible = showTechnicalDetails,
-                    enter = slideInVertically {
-                        with(density) { -20.dp.roundToPx() }
-                    } + expandVertically(
-                        expandFrom = Alignment.Top
-                    ) + fadeIn(
-                        initialAlpha = 0.3f
-                    ),
-                    exit = slideOutVertically {
-                        with(density) { 20.dp.roundToPx() }
-                    } + shrinkVertically(
-                        shrinkTowards = Alignment.Bottom
-                    ) + fadeOut(
-                        targetAlpha = 0f
-                    )
-                ) {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        LabeledContent(
-                            label = stringResource(Res.string.text_label_thumbprint),
-                            content = {
-                                Text(
-                                    text = digest,
-                                    softWrap = true,
-                                )
-                            },
-                            modifier = contentPadding
-                        )
-
-                        LabeledContent(
-                            label = stringResource(Res.string.text_label_valid_from),
-                            content = {
-                                Text(
-                                    text = validFrom,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            },
-                            modifier = contentPadding
-                        )
-
-                        LabeledContent(
-                            label = stringResource(Res.string.text_label_valid_to),
-                            content = {
-                                Text(
-                                    text = validUntil,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            },
-                            modifier = contentPadding
-                        )
-                    }
-                }
-            }
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { showTechnicalDetails = !showTechnicalDetails },
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Label(
-                label = if (showTechnicalDetails) {
-                    stringResource(Res.string.button_label_hide_technical_details)
-                } else {
-                    stringResource(Res.string.button_label_show_technical_details)
-                }
+    ElevatedCard(modifier = modifier.padding(bottom = 16.dp)) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            PersonAttributeDetailCardHeading(
+                iconText = stringResource(Res.string.section_heading_issuer_trust_icon_text),
+                title = stringResource(Res.string.section_heading_issuer_trust),
             )
-            Icon(
-                imageVector = if (showTechnicalDetails) {
-                    Icons.Outlined.ArrowUpward
-                } else {
-                    Icons.Outlined.ArrowDownward
+
+            LabeledText(
+                label = stringResource(Res.string.text_label_issued_by),
+                text = issuerName,
+                modifier = contentPadding,
+                fontWeight = FontWeight.Normal
+            )
+
+            LabeledText(
+                label = stringResource(Res.string.text_label_trust_status),
+                text = displayTrust,
+                modifier = contentPadding,
+                fontWeight = FontWeight.Normal
+            )
+
+            LabeledContent(
+                label = stringResource(Res.string.text_label_thumbprint),
+                content = {
+                    Text(
+                        text = digest,
+                        softWrap = true,
+                    )
                 },
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.secondary
+                modifier = contentPadding
+            )
+
+            LabeledContent(
+                label = stringResource(Res.string.text_label_valid_from),
+                content = {
+                    Text(
+                        text = validFrom,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                modifier = contentPadding
+            )
+
+            LabeledContent(
+                label = stringResource(Res.string.text_label_valid_to),
+                content = {
+                    Text(
+                        text = validUntil,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
+                modifier = contentPadding
             )
         }
     }

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/CredentialSelectionCardHeader.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/CredentialSelectionCardHeader.kt
@@ -4,13 +4,9 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import at.asitplus.valera.resources.Res
-import at.asitplus.valera.resources.error_credential_matching_failed
 import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.agent.representation
 import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.data.iconLabel
 import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.data.uiLabel
-import org.jetbrains.compose.resources.stringResource
-import ui.composables.BigErrorText
 import ui.composables.LabeledText
 import ui.composables.PersonAttributeDetailCardHeading
 import ui.composables.PersonAttributeDetailCardHeadingIcon
@@ -37,11 +33,9 @@ fun ColumnScope.CredentialSelectionCardHeader(
             )
         },
         actionButtons = {
-            when(val it = credentialFreshnessValidationState) {
+            when (val it = credentialFreshnessValidationState) {
                 CredentialFreshnessValidationStateUiModel.Loading -> CircularProgressIndicator()
-                is CredentialFreshnessValidationStateUiModel.Done -> if(matchingException != null) {
-                    BigErrorText(stringResource(Res.string.error_credential_matching_failed))
-                } else {
+                is CredentialFreshnessValidationStateUiModel.Done -> if (matchingException == null) {
                     MainCredentialIssue(it.credentialFreshnessSummary)
                 }
             }

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/GenericCredentialSummaryCardContent.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/GenericCredentialSummaryCardContent.kt
@@ -74,6 +74,7 @@ import kotlin.time.Instant
 fun GenericCredentialSummaryCardContent(
     credential: ResolvedCredential,
     modifier: Modifier = Modifier,
+    additionalContent: @Composable ColumnScope.() -> Unit = {},
 ) {
 
     var showContent by remember {
@@ -107,6 +108,7 @@ fun GenericCredentialSummaryCardContent(
                 is StoreEntry.SdJwt -> SingleSdJwtCredentialCardContent(entry)
                 is StoreEntry.Iso -> SingleIsoCredentialCardContent(entry)
             }
+            additionalContent()
         }
     }
     Column(

--- a/shared/src/commonMain/kotlin/ui/composables/credentials/GenericCredentialSummaryCardContent.kt
+++ b/shared/src/commonMain/kotlin/ui/composables/credentials/GenericCredentialSummaryCardContent.kt
@@ -61,10 +61,12 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.longOrNull
 import org.jetbrains.compose.resources.stringResource
+import ui.composables.IssuerTrustDetailsCard
 import ui.composables.Label
 import ui.composables.LabeledContent
 import ui.composables.LabeledText
 import ui.composables.PersonAttributeDetailCardHeading
+import ui.composables.TrustState
 import ui.models.ResolvedCredential
 import kotlin.math.min
 import kotlin.time.Instant
@@ -73,8 +75,8 @@ import kotlin.time.Instant
 @Composable
 fun GenericCredentialSummaryCardContent(
     credential: ResolvedCredential,
+    trustState: TrustState,
     modifier: Modifier = Modifier,
-    additionalContent: @Composable ColumnScope.() -> Unit = {},
 ) {
 
     var showContent by remember {
@@ -104,11 +106,10 @@ fun GenericCredentialSummaryCardContent(
             modifier = modifier
         ) {
             when (val entry = credential.entry) {
-                is StoreEntry.Vc -> SingleVcCredentialCardContent(entry)
-                is StoreEntry.SdJwt -> SingleSdJwtCredentialCardContent(entry)
-                is StoreEntry.Iso -> SingleIsoCredentialCardContent(entry)
+                is StoreEntry.Vc -> SingleVcCredentialCardContent(entry, trustState)
+                is StoreEntry.SdJwt -> SingleSdJwtCredentialCardContent(entry, trustState)
+                is StoreEntry.Iso -> SingleIsoCredentialCardContent(entry, trustState)
             }
-            additionalContent()
         }
     }
     Column(
@@ -136,6 +137,7 @@ fun GenericCredentialSummaryCardContent(
 @Composable
 private fun SingleVcCredentialCardContent(
     credential: StoreEntry.Vc,
+    trustState: TrustState,
 ) {
     val modifier = Modifier.padding(bottom = 16.dp, end = 16.dp, start = 16.dp)
     ElevatedCard(modifier = Modifier.padding(bottom = 16.dp)) {
@@ -148,6 +150,7 @@ private fun SingleVcCredentialCardContent(
         }
     }
     (credential.vc.vc.credentialStatus as? StatusListInfo)?.let { StatusCard(it, modifier) }
+    credential.issuer?.let { IssuerTrustDetailsCard(it, trustState) }
     CredentialContentsCard {
         when (val subject = credential.vc.vc.credentialSubject) {
             is JsonObject -> subject.mapWithPrefix().sortedBy { it.first }.toSet().forEach {
@@ -171,6 +174,7 @@ private fun SingleVcCredentialCardContent(
 @Composable
 private fun SingleSdJwtCredentialCardContent(
     credential: StoreEntry.SdJwt,
+    trustState: TrustState,
 ) {
     val modifier = Modifier.padding(bottom = 16.dp, end = 16.dp, start = 16.dp)
     ElevatedCard(modifier = Modifier.padding(bottom = 16.dp)) {
@@ -189,6 +193,7 @@ private fun SingleSdJwtCredentialCardContent(
         }
     }
     (credential.sdJwt.statusElement as? StatusListInfo)?.let { StatusCard(it, modifier) }
+    credential.issuer?.let { IssuerTrustDetailsCard(it, trustState) }
     (credential.toComplexJson()?.get("cnf") as? JsonObject)?.let { CnfCard(it, modifier) }
     credential.allEntries().takeIf { it.isNotEmpty() }?.let { entries ->
         CredentialContentsCard {
@@ -223,6 +228,7 @@ private fun JsonObject.mapWithPrefix(prefix: String? = null): Collection<Pair<St
 @Composable
 private fun SingleIsoCredentialCardContent(
     credential: StoreEntry.Iso,
+    trustState: TrustState,
 ) {
     val modifier = Modifier.padding(bottom = 16.dp, end = 16.dp, start = 16.dp)
     ElevatedCard(modifier = Modifier.padding(bottom = 16.dp)) {
@@ -238,6 +244,7 @@ private fun SingleIsoCredentialCardContent(
         }
     }
     (credential.issuerSigned.issuerAuth.payload?.status as? StatusListInfo)?.let { StatusCard(it, modifier) }
+    credential.issuer?.let { IssuerTrustDetailsCard(it, trustState) }
     (credential.issuerSigned.namespaces?.mapIt() ?: listOf()).sortedBy { it.first }.takeIf { it.isNotEmpty() }
         ?.let { entries ->
             CredentialContentsCard {

--- a/shared/src/commonMain/kotlin/ui/views/CredentialDetailsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/CredentialDetailsView.kt
@@ -33,7 +33,6 @@ import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.data.isMd
 import at.asitplus.wallet.app.common.thirdParty.at.asitplus.wallet.lib.data.uiLabel
 import org.jetbrains.compose.resources.stringResource
 import ui.composables.CredentialCardActionMenu
-import ui.composables.IssuerTrustDetailsCard
 import ui.composables.LabeledText
 import ui.composables.Logo
 import ui.composables.PersonAttributeDetailCardHeading
@@ -150,12 +149,6 @@ fun CredentialDetailsSummaryView(
     imageDecoder: (ByteArray) -> Result<ImageBitmap>,
 ) {
     Column(modifier = Modifier.padding(horizontal = 8.dp)) {
-
-        TrustStatusBanner(
-            trustState = trustState,
-            modifier = Modifier.padding(vertical = 12.dp)
-        )
-
         PersonAttributeDetailCardHeading(
             icon = { PersonAttributeDetailCardHeadingIcon(credential.scheme.iconLabel()) },
             title = {
@@ -164,6 +157,10 @@ fun CredentialDetailsSummaryView(
                     text = credential.scheme.uiLabel(),
                 )
             },
+        )
+        TrustStatusBanner(
+            trustState = trustState,
+            modifier = Modifier.padding(vertical = 12.dp)
         )
         credential.scheme.let { s ->
             when {
@@ -174,15 +171,10 @@ fun CredentialDetailsSummaryView(
         }
         // No extra horizontal padding here: the enclosing Column already applies it, otherwise the cards
         // (technical data, status, contents, cnf) would be indented twice.
-        GenericCredentialSummaryCardContent(credential = credential) {
-            credential.entry.issuer?.let { issuerCert ->
-                IssuerTrustDetailsCard(
-                    certificate = issuerCert,
-                    trustState = trustState,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
+        GenericCredentialSummaryCardContent(
+            credential = credential,
+            trustState = trustState
+        )
         Spacer(modifier = Modifier.height(16.dp))
     }
 }

--- a/shared/src/commonMain/kotlin/ui/views/CredentialDetailsView.kt
+++ b/shared/src/commonMain/kotlin/ui/views/CredentialDetailsView.kt
@@ -174,15 +174,14 @@ fun CredentialDetailsSummaryView(
         }
         // No extra horizontal padding here: the enclosing Column already applies it, otherwise the cards
         // (technical data, status, contents, cnf) would be indented twice.
-        GenericCredentialSummaryCardContent(credential = credential)
-
-        Spacer(modifier = Modifier.height(16.dp))
-        credential.entry.issuer?.let { issuerCert ->
-            IssuerTrustDetailsCard(
-                certificate = issuerCert,
-                trustState = trustState,
-                modifier = Modifier.fillMaxWidth()
-            )
+        GenericCredentialSummaryCardContent(credential = credential) {
+            credential.entry.issuer?.let { issuerCert ->
+                IssuerTrustDetailsCard(
+                    certificate = issuerCert,
+                    trustState = trustState,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
         Spacer(modifier = Modifier.height(16.dp))
     }


### PR DESCRIPTION
 * Update to VC-K 7.0.0
 * Rework resolving credential schemes
 * Drop support for PID in VC JWT (which was never officially specified anyway)
 * DCAPI: Update matching implementation, improve iOS state handling
 * Fix opening second provisioning flow after aborting the first one
 * Add `TrustListService` for loading LoTE regularly in the background
 * Display trust evaluation of credentials
 * Cache remote lookups of trust lists and status lists
 * Improve dark theme
 * Improve UI performance