### PR TITLE
Remove redundant StatusListTokenResolver

### DIFF
--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/data/primitives/CachingStatusListTokenResolver.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/data/primitives/CachingStatusListTokenResolver.kt
@@ -1,6 +1,6 @@
 package at.asitplus.wallet.app.common.data.primitives
 
-import at.asitplus.wallet.app.common.domain.vck.tokenStatusList.StatusListTokenResolver
+import at.asitplus.wallet.lib.agent.validation.StatusListTokenResolver
 import at.asitplus.wallet.lib.data.StatusListToken
 import at.asitplus.wallet.lib.data.rfc3986.UniformResourceIdentifier
 
@@ -11,8 +11,8 @@ data class CachingStatusListTokenResolver(
     val store: SimpleStore<UniformResourceIdentifier, StatusListToken>,
     val statusListTokenResolver: StatusListTokenResolver,
 ) : StatusListTokenResolver {
-    override suspend fun invoke(uniformResourceIdentifier: UniformResourceIdentifier) =
-        store.getOrPut(uniformResourceIdentifier) {
-            statusListTokenResolver(uniformResourceIdentifier)
+    override suspend fun invoke(statusListUrl: UniformResourceIdentifier) =
+        store.getOrPut(statusListUrl) {
+            statusListTokenResolver(statusListUrl)
         }
 }

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/di/VckModule.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/di/VckModule.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.app.common.domain.vck.di
 import at.asitplus.wallet.app.common.SESSION_NAME
 import at.asitplus.wallet.app.common.domain.vck.JsonWebKeySetResolver
 import at.asitplus.wallet.app.common.domain.vck.PublicKeyResolver
-import at.asitplus.wallet.app.common.domain.vck.tokenStatusList.StatusListTokenResolver
 import at.asitplus.wallet.app.common.domain.vck.tokenStatusList.di.tokenStatusListModule
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
@@ -11,6 +10,7 @@ import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.agent.Validator
 import at.asitplus.wallet.lib.agent.ValidatorSdJwt
 import at.asitplus.wallet.lib.agent.ValidatorVcJws
+import at.asitplus.wallet.lib.agent.validation.StatusListTokenResolver
 import at.asitplus.wallet.lib.agent.validation.TokenStatusResolverImpl
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import org.koin.core.module.dsl.singleOf

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/tokenStatusList/StatusListTokenResolver.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/tokenStatusList/StatusListTokenResolver.kt
@@ -1,8 +1,0 @@
-package at.asitplus.wallet.app.common.domain.vck.tokenStatusList
-
-import at.asitplus.wallet.lib.data.StatusListToken
-import at.asitplus.wallet.lib.data.rfc3986.UniformResourceIdentifier
-
-fun interface StatusListTokenResolver {
-    suspend operator fun invoke(uniformResourceIdentifier: UniformResourceIdentifier): StatusListToken
-}

--- a/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/tokenStatusList/di/TokenStatusListModule.kt
+++ b/shared/src/commonMain/kotlin/at/asitplus/wallet/app/common/domain/vck/tokenStatusList/di/TokenStatusListModule.kt
@@ -8,7 +8,7 @@ import at.asitplus.wallet.app.common.SESSION_NAME
 import at.asitplus.wallet.app.common.data.primitives.CachingStatusListTokenResolver
 import at.asitplus.wallet.app.common.data.primitives.SimpleBootstrappingBulkStore
 import at.asitplus.wallet.app.common.data.primitives.SimpleCacheStoreWrapper
-import at.asitplus.wallet.app.common.domain.vck.tokenStatusList.StatusListTokenResolver
+import at.asitplus.wallet.lib.agent.validation.StatusListTokenResolver
 import at.asitplus.wallet.lib.data.StatusListJwt
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.MediaTypes
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload


### PR DESCRIPTION
Removed because we have the same interface in vck:
https://github.com/a-sit-plus/vck/blob/main/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/StatusListTokenResolver.kt